### PR TITLE
Result: make safe

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -88,21 +88,6 @@ class Result {
    }
 
    /**
-    * Returns the Result's value or calls `$alternativeFactory` and returns the value of that function
-    *
-    * _Notes:_
-    *
-    *  - `$alternativeFactory` must follow this interface `callable(Throwable):TOkay`
-    *
-    * @param callable(Throwable):TOkay $alternativeFactory
-    * @return TOkay
-    **/
-   public function dataOrReturn(callable $alternativeFactory) {
-      /** @var TOkay **/
-      return $this->either->leftOrCreate($alternativeFactory);
-   }
-
-   /**
     * Returns a `Result::okay($value)` iff the the Result orginally was `Result::error($errorValue)`
     *
     * The `$alternativeFactory` is called lazily - iff the Result orginally was `Result::error($errorValue)`

--- a/src/Result.php
+++ b/src/Result.php
@@ -121,8 +121,13 @@ class Result {
     * @return Result<TOkay, Exception|string>
     **/
    public function orCreateResultWithData(callable $alternativeFactory): self {
-      $either = $this->either->orCreateLeft($alternativeFactory);
-      return new self($either);
+      try {
+         $either = $this->either->orCreateLeft($alternativeFactory);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -163,8 +168,13 @@ class Result {
          return $result->either;
       };
 
-      $either = $this->either->elseCreateLeft($realFactory);
-      return new self($either);
+      try {
+         $either = $this->either->elseCreateLeft($realFactory);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -214,26 +224,6 @@ class Result {
    }
 
    /**
-    * Maps the `$value` of a `Result::okay($value)`
-    *
-    * The `map` function runs iff the Result is a `Result::okay`
-    * Otherwise the `Result:error($errorValue)` is propagated
-    *
-    * _Notes:_
-    *
-    *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
-    *  - Returns `Result<UOkay, Exception|string>`
-    *
-    * @template UOkay
-    * @param callable(TOkay):UOkay $mapFunc
-    * @return Result<UOkay, Exception|string>
-    **/
-   public function map(callable $mapFunc): self {
-      $either = $this->either->mapLeft($mapFunc);
-      return new self($either);
-   }
-
-   /**
     * `map`, but if an exception occurs, return `Result::error(exception)`
     *
     * The `map` function runs iff the Result is a `Result::okay`
@@ -248,7 +238,7 @@ class Result {
     * @param callable(TOkay):UOkay $mapFunc
     * @return Result<UOkay, Exception|string>
     **/
-   public function mapSafely(callable $mapFunc): self {
+   public function map(callable $mapFunc): self {
       $either = $this->either->mapLeftSafely($mapFunc);
       return new self($either);
    }
@@ -268,8 +258,13 @@ class Result {
     * @return Result<TOkay, Exception|string>
     **/
    public function mapError(callable $mapFunc): self {
-      $either = $this->either->mapRight($mapFunc);
-      return new self($either);
+      try {
+         $either = $this->either->mapRight($mapFunc);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -310,8 +305,13 @@ class Result {
          return $result->either;
       };
 
-      $either = $this->either->flatMapLeft($realMap);
-      return new self($either);
+      try {
+         $either = $this->either->flatMapLeft($realMap);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -346,8 +346,13 @@ class Result {
     * @return Result<TOkay, Exception|string>
     **/
    public function toErrorIf(callable $filterFunc, $errorValue): self {
-      $either = $this->either->filterLeftIf($filterFunc, $errorValue);
-      return new self($either);
+      try {
+         $either = $this->either->filterLeftIf($filterFunc, $errorValue);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -364,8 +369,13 @@ class Result {
     * @return Result<TOkay, Exception|string>
     **/
    public function toOkayIf(callable $filterFunc, $data): self {
-      $either = $this->either->filterRightIf($filterFunc, $data);
-      return new self($either);
+      try {
+         $either = $this->either->filterRightIf($filterFunc, $data);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -444,8 +454,13 @@ class Result {
     * @return Result<TOkay, Exception|string>
     **/
    public static function okayWhen($data, $errorValue, callable $filterFunc): self {
-      $either = Either::leftWhen($data, $errorValue, $filterFunc);
-      return new self($either);
+      try {
+         $either = Either::leftWhen($data, $errorValue, $filterFunc);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**
@@ -463,8 +478,13 @@ class Result {
     * @return Result<TOkay, Exception|string>
     **/
    public static function errorWhen($data, $errorValue, callable $filterFunc): self {
-      $either = Either::rightWhen($data, $errorValue, $filterFunc);
-      return new self($either);
+      try {
+         $either = Either::rightWhen($data, $errorValue, $filterFunc);
+         return new self($either);
+      } catch (\Exception $e) {
+         $either = Either::right($e);
+         return new self($either);
+      }
    }
 
    /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -56,14 +56,19 @@ class Result {
    }
 
    /**
-    * Returns the Result value or returns `$alternative`
+    * Returns the Result value or throws the current error
     *
-    * @param TOkay $alternative
     * @return TOkay
     **/
-   public function dataOr($alternative) {
-      /** @var TOkay **/
-      return $this->either->leftOr($alternative);
+   public function dataOrThrow() {
+      if ($this->either->isLeft()) {
+         /** @var TOkay **/
+         return $this->either->leftOr(null);
+      } else {
+         /** @var TError **/
+         $ex = $this->either->rightOr(null);
+         throw new Exception($ex->getMessage(), (int)$ex->getCode(), $ex);
+      }
    }
 
    /**

--- a/src/Result.php
+++ b/src/Result.php
@@ -10,7 +10,7 @@ use Exception;
 
 /**
  * @template TOkay
- * @template TError as Exception|string
+ * @template TError as Exception
  */
 class Result {
    /** @var Either */
@@ -25,7 +25,7 @@ class Result {
 
    /**
     * @param TOkay $data
-    * @return Result<TOkay, Exception|string>
+    * @return Result<TOkay, Exception>
     **/
    public static function okay($data): self {
       $either = Either::left($data);
@@ -33,10 +33,10 @@ class Result {
    }
 
    /**
-    * @param  Exception|string $errorData
-    * @return Result<TOkay, Exception|string>
+    * @param  Exception $errorData
+    * @return Result<TOkay, Exception>
     **/
-   public static function error($errorData): self {
+   public static function error(Exception $errorData): self {
       $either = Either::right($errorData);
       return new self($either);
    }
@@ -67,25 +67,14 @@ class Result {
    }
 
    /**
-    * Returns the Result erro value or returns `$alternative`
-    *
-    * @param Exception|string $alternative
-    * @return Exception|string
-    **/
-   public function errorOr($alternative) {
-      /** @var Exception|string **/
-      return $this->either->rightOr($alternative);
-   }
-
-   /**
     * Returns a `Result::okay($data)` iff the Result orginally was `Result::error($errorValue)`
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay,  Exception|string>`
+    *  - Returns `Result<TOkay,  Exception>`
     *
     * @param TOkay $data
-    * @return Result<TOkay,  Exception|string>
+    * @return Result<TOkay,  Exception>
     **/
    public function orSetDataTo($data): self {
       $either = $this->either->orLeft($data);
@@ -97,9 +86,9 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(Exception|string):TOkay`
+    *  - `$alternativeFactory` must follow this interface `callable(Exception):TOkay`
     *
-    * @param callable(Exception|string):TOkay $alternativeFactory
+    * @param callable(Exception):TOkay $alternativeFactory
     * @return TOkay
     **/
    public function dataOrReturn(callable $alternativeFactory) {
@@ -114,11 +103,11 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(Exception|string):TOkay`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - `$alternativeFactory` must follow this interface `callable(Exception):TOkay`
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param callable(Exception|string):TOkay $alternativeFactory
-    * @return Result<TOkay, Exception|string>
+    * @param callable(Exception):TOkay $alternativeFactory
+    * @return Result<TOkay, Exception>
     **/
    public function orCreateResultWithData(callable $alternativeFactory): self {
       try {
@@ -135,11 +124,11 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeResult` must be of type `Result<TOkay, Exception|string>`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - `$alternativeResult` must be of type `Result<TOkay, Exception>`
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param Result<TOkay, Exception|string> $alternativeResult
-    * @return Result<TOkay, Exception|string>
+    * @param Result<TOkay, Exception> $alternativeResult
+    * @return Result<TOkay, Exception>
     **/
    public function  okayOr(self $alternativeResult): self {
       $either = $this->either->elseLeft($alternativeResult->either);
@@ -153,17 +142,17 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeResultFactory` must be of type `callable(Exception|string):Result<TOkay, Exception|string> `
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - `$alternativeResultFactory` must be of type `callable(Exception):Result<TOkay, Exception> `
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param callable(Exception|string):Result<TOkay, Exception|string> $alternativeResultFactory
-    * @return Result<TOkay, Exception|string>
+    * @param callable(Exception):Result<TOkay, Exception> $alternativeResultFactory
+    * @return Result<TOkay, Exception>
     **/
    public function createIfError(callable $alternativeResultFactory): self {
-      /** @var callable(TOkay):Either<TOkay, Exception|string> **/
+      /** @var callable(TOkay):Either<TOkay, Exception> **/
       $realFactory =
-      /** @param Exception|string $errorValue */
-      function ($errorValue) use ($alternativeResultFactory): Either {
+      /** @param Exception $errorValue */
+      function (Exception $errorValue) use ($alternativeResultFactory): Either {
          $result = $alternativeResultFactory($errorValue);
          return $result->either;
       };
@@ -186,11 +175,11 @@ class Result {
     * _Notes:_
     *
     *  - `$dataFunc` must follow this interface `callable(TOkay):U`
-    *  - `$errorFunc` must follow this interface `callable(Exception|string):U`
+    *  - `$errorFunc` must follow this interface `callable(Exception):U`
     *
     * @template U
     * @param callable(TOkay):U $dataFunc
-    * @param callable(Exception|string):U $errorFunc
+    * @param callable(Exception):U $errorFunc
     * @return U
     **/
    public function run(callable $dataFunc, callable $errorFunc) {
@@ -215,9 +204,9 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$errorFunc` must follow this interface `callable(Exception|string):U`
+    *  - `$errorFunc` must follow this interface `callable(Exception):U`
     *
-    * @param callable(Exception|string) $errorFunc
+    * @param callable(Exception) $errorFunc
     **/
    public function runOnError(callable $errorFunc): void {
       $this->either->matchRight($errorFunc);
@@ -232,11 +221,11 @@ class Result {
     * _Notes:_
     *
     *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
-    *  - Returns `Result<UOkay, Exception|string>`
+    *  - Returns `Result<UOkay, Exception>`
     *
     * @template UOkay
     * @param callable(TOkay):UOkay $mapFunc
-    * @return Result<UOkay, Exception|string>
+    * @return Result<UOkay, Exception>
     **/
    public function map(callable $mapFunc): self {
       $either = $this->either->mapLeftSafely($mapFunc);
@@ -251,11 +240,11 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$mapFunc` must follow this interface `callable(Exception|string):Exception|string`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - `$mapFunc` must follow this interface `callable(Exception):Exception`
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param callable(Exception|string):Exception|string $mapFunc
-    * @return Result<TOkay, Exception|string>
+    * @param callable(Exception):Exception $mapFunc
+    * @return Result<TOkay, Exception>
     **/
    public function mapError(callable $mapFunc): self {
       try {
@@ -273,12 +262,12 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, Exception|string>`
-    *  - Returns `Result<UOkay, Exception|string>`
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, Exception>`
+    *  - Returns `Result<UOkay, Exception>`
     *
     * @template UOkay
-    * @param callable(TOkay):Result<UOkay, Exception|string> $mapFunc
-    * @return Result<UOkay, Exception|string>
+    * @param callable(TOkay):Result<UOkay, Exception> $mapFunc
+    * @return Result<UOkay, Exception>
     **/
    public function andThen(callable $mapFunc): self {
       return $this->flatMap($mapFunc);
@@ -289,15 +278,15 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, Exception|string>`
-    *  - Returns `Result<UOkay, Exception|string>`
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, Exception>`
+    *  - Returns `Result<UOkay, Exception>`
     *
     * @template UOkay
-    * @param callable(TOkay):Result<UOkay, Exception|string> $mapFunc
-    * @return Result<UOkay, Exception|string>
+    * @param callable(TOkay):Result<UOkay, Exception> $mapFunc
+    * @return Result<UOkay, Exception>
     **/
    public function flatMap(callable $mapFunc): self {
-      /** @var callable(TOkay):Either<UOkay, Exception|string> **/
+      /** @var callable(TOkay):Either<UOkay, Exception> **/
       $realMap =
       /** @param TOkay $data */
       function ($data) use ($mapFunc): Either {
@@ -315,8 +304,8 @@ class Result {
    }
 
    /**
-    * @param Exception|string $errorValue
-    * @return Result<TOkay, Exception|string>
+    * @param Exception $errorValue
+    * @return Result<TOkay, Exception>
     **/
    public function toError($errorValue): self {
       $either = $this->either->filterLeft(false, $errorValue);
@@ -325,7 +314,7 @@ class Result {
 
    /**
     * @param TOkay $dataValue
-    * @return Result<TOkay, Exception|string>
+    * @return Result<TOkay, Exception>
     **/
    public function toOkay($dataValue): self {
       $either = $this->either->filterRight(false, $dataValue);
@@ -339,13 +328,13 @@ class Result {
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay):bool`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - Returns `Result<TOkay, Exception>`
     *
     * @param callable(TOkay):bool $filterFunc
-    * @param Exception|string $errorValue
-    * @return Result<TOkay, Exception|string>
+    * @param Exception $errorValue
+    * @return Result<TOkay, Exception>
     **/
-   public function toErrorIf(callable $filterFunc, $errorValue): self {
+   public function toErrorIf(callable $filterFunc, Exception $errorValue): self {
       try {
          $either = $this->either->filterLeftIf($filterFunc, $errorValue);
          return new self($either);
@@ -361,12 +350,12 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$filterFunc` must follow this interface `callable(Exception|string):bool`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - `$filterFunc` must follow this interface `callable(Exception):bool`
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param callable(Exception|string):bool $filterFunc
+    * @param callable(Exception):bool $filterFunc
     * @param TOkay $data
-    * @return Result<TOkay, Exception|string>
+    * @return Result<TOkay, Exception>
     **/
    public function toOkayIf(callable $filterFunc, $data): self {
       try {
@@ -383,12 +372,12 @@ class Result {
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param Exception|string $errorValue
-    * @return Result<TOkay, Exception|string>
+    * @param Exception $errorValue
+    * @return Result<TOkay, Exception>
     **/
-   public function notNull($errorValue): self {
+   public function notNull(Exception $errorValue): self {
       $either = $this->either->leftNotNull($errorValue);
       return new self($either);
    }
@@ -398,12 +387,12 @@ class Result {
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - Returns `Result<TOkay, Exception>`
     *
-    * @param Exception|string $errorValue
-    * @return Result<TOkay, Exception|string>
+    * @param Exception $errorValue
+    * @return Result<TOkay, Exception>
     **/
-   public function notFalsy($errorValue): self {
+   public function notFalsy(Exception $errorValue): self {
       $either = $this->either->leftNotFalsy($errorValue);
       return new self($either);
    }
@@ -446,14 +435,14 @@ class Result {
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - Returns `Result<TOkay, Exception>`
     *
     * @param TOkay $data
-    * @param Exception|string $errorValue
+    * @param Exception $errorValue
     * @param callable(TOkay): bool $filterFunc
-    * @return Result<TOkay, Exception|string>
+    * @return Result<TOkay, Exception>
     **/
-   public static function okayWhen($data, $errorValue, callable $filterFunc): self {
+   public static function okayWhen($data, Exception $errorValue, callable $filterFunc): self {
       try {
          $either = Either::leftWhen($data, $errorValue, $filterFunc);
          return new self($either);
@@ -470,14 +459,14 @@ class Result {
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
-    *  - Returns `Result<TOkay, Exception|string>`
+    *  - Returns `Result<TOkay, Exception>`
     *
     * @param TOkay $data
-    * @param Exception|string $errorValue
+    * @param Exception $errorValue
     * @param callable(TOkay): bool $filterFunc
-    * @return Result<TOkay, Exception|string>
+    * @return Result<TOkay, Exception>
     **/
-   public static function errorWhen($data, $errorValue, callable $filterFunc): self {
+   public static function errorWhen($data, Exception $errorValue, callable $filterFunc): self {
       try {
          $either = Either::rightWhen($data, $errorValue, $filterFunc);
          return new self($either);
@@ -492,13 +481,13 @@ class Result {
     *
     * _Notes:_
     *
-    * - Returns `Result<TOkay, Exception|string>`
+    * - Returns `Result<TOkay, Exception>`
     *
     * @param TOkay $data
-    * @param Exception|string $errorValue
-    * @return Result<TOkay, Exception|string>
+    * @param Exception $errorValue
+    * @return Result<TOkay, Exception>
     **/
-   public static function okayNotNull($data, $errorValue): self {
+   public static function okayNotNull($data, Exception $errorValue): self {
       $either = Either::notNullLeft($data, $errorValue);
       return new self($either);
    }
@@ -508,14 +497,14 @@ class Result {
     *
     * _Notes:_
     *
-    * - Returns `Result<TOkay, Exception|string>`
+    * - Returns `Result<TOkay, Exception>`
     *
     * @param array<array-key, mixed> $array
     * @param array-key $key The key of the array
-    * @param Exception|string $rightValue
-    *  @return Result<TOkay, Exception|string>
+    * @param Exception $rightValue
+    *  @return Result<TOkay, Exception>
     **/
-   public static function fromArray(array $array, $key, $rightValue = null): self {
+   public static function fromArray(array $array, $key, Exception $rightValue = null): self {
       $either = Either::fromArray($array, $key, $rightValue);
       return new self($either);
    }

--- a/src/Result.php
+++ b/src/Result.php
@@ -6,9 +6,11 @@ namespace Optional;
 
 use Optional\Either;
 
+use Exception;
+
 /**
  * @template TOkay
- * @template TError
+ * @template TError as Exception|string
  */
 class Result {
    /** @var Either */
@@ -23,7 +25,7 @@ class Result {
 
    /**
     * @param TOkay $data
-    * @return Result<TOkay, TError>
+    * @return Result<TOkay, Exception|string>
     **/
    public static function okay($data): self {
       $either = Either::left($data);
@@ -31,8 +33,8 @@ class Result {
    }
 
    /**
-    * @param TError $errorData
-    * @return Result<TOkay, TError>
+    * @param  Exception|string $errorData
+    * @return Result<TOkay, Exception|string>
     **/
    public static function error($errorData): self {
       $either = Either::right($errorData);
@@ -67,11 +69,11 @@ class Result {
    /**
     * Returns the Result erro value or returns `$alternative`
     *
-    * @param TError $alternative
-    * @return TError
+    * @param Exception|string $alternative
+    * @return Exception|string
     **/
    public function errorOr($alternative) {
-      /** @var TError **/
+      /** @var Exception|string **/
       return $this->either->rightOr($alternative);
    }
 
@@ -80,10 +82,10 @@ class Result {
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay,  Exception|string>`
     *
     * @param TOkay $data
-    * @return Result<TOkay, TError>
+    * @return Result<TOkay,  Exception|string>
     **/
    public function orSetDataTo($data): self {
       $either = $this->either->orLeft($data);
@@ -95,9 +97,9 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TError):TOkay`
+    *  - `$alternativeFactory` must follow this interface `callable(Exception|string):TOkay`
     *
-    * @param callable(TError):TOkay $alternativeFactory
+    * @param callable(Exception|string):TOkay $alternativeFactory
     * @return TOkay
     **/
    public function dataOrReturn(callable $alternativeFactory) {
@@ -112,11 +114,11 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TError):TOkay`
-    *  - Returns `Result<TOkay, TError>`
+    *  - `$alternativeFactory` must follow this interface `callable(Exception|string):TOkay`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @param callable(TError):TOkay $alternativeFactory
-    * @return Result<TOkay, TError>
+    * @param callable(Exception|string):TOkay $alternativeFactory
+    * @return Result<TOkay, Exception|string>
     **/
    public function orCreateResultWithData(callable $alternativeFactory): self {
       $either = $this->either->orCreateLeft($alternativeFactory);
@@ -128,11 +130,11 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeResult` must be of type `Result<TOkay, TError>`
-    *  - Returns `Result<TOkay, TError>`
+    *  - `$alternativeResult` must be of type `Result<TOkay, Exception|string>`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @param Result<TOkay, TError> $alternativeResult
-    * @return Result<TOkay, TError>
+    * @param Result<TOkay, Exception|string> $alternativeResult
+    * @return Result<TOkay, Exception|string>
     **/
    public function  okayOr(self $alternativeResult): self {
       $either = $this->either->elseLeft($alternativeResult->either);
@@ -146,16 +148,16 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeResultFactory` must be of type `callable(TError):Result<TOkay, TError> `
-    *  - Returns `Result<TOkay, TError>`
+    *  - `$alternativeResultFactory` must be of type `callable(Exception|string):Result<TOkay, Exception|string> `
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @param callable(TError):Result<TOkay, TError> $alternativeResultFactory
-    * @return Result<TOkay, TError>
+    * @param callable(Exception|string):Result<TOkay, Exception|string> $alternativeResultFactory
+    * @return Result<TOkay, Exception|string>
     **/
    public function createIfError(callable $alternativeResultFactory): self {
-      /** @var callable(TOkay):Either<TOkay, TError> **/
+      /** @var callable(TOkay):Either<TOkay, Exception|string> **/
       $realFactory =
-      /** @param TError $errorValue */
+      /** @param Exception|string $errorValue */
       function ($errorValue) use ($alternativeResultFactory): Either {
          $result = $alternativeResultFactory($errorValue);
          return $result->either;
@@ -174,11 +176,11 @@ class Result {
     * _Notes:_
     *
     *  - `$dataFunc` must follow this interface `callable(TOkay):U`
-    *  - `$errorFunc` must follow this interface `callable(TError):U`
+    *  - `$errorFunc` must follow this interface `callable(Exception|string):U`
     *
     * @template U
     * @param callable(TOkay):U $dataFunc
-    * @param callable(TError):U $errorFunc
+    * @param callable(Exception|string):U $errorFunc
     * @return U
     **/
    public function run(callable $dataFunc, callable $errorFunc) {
@@ -203,9 +205,9 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$errorFunc` must follow this interface `callable(TError):U`
+    *  - `$errorFunc` must follow this interface `callable(Exception|string):U`
     *
-    * @param callable(TError) $errorFunc
+    * @param callable(Exception|string) $errorFunc
     **/
    public function runOnError(callable $errorFunc): void {
       $this->either->matchRight($errorFunc);
@@ -220,11 +222,11 @@ class Result {
     * _Notes:_
     *
     *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
-    *  - Returns `Result<UOkay, TError>`
+    *  - Returns `Result<UOkay, Exception|string>`
     *
     * @template UOkay
     * @param callable(TOkay):UOkay $mapFunc
-    * @return Result<UOkay, TError>
+    * @return Result<UOkay, Exception|string>
     **/
    public function map(callable $mapFunc): self {
       $either = $this->either->mapLeft($mapFunc);
@@ -240,11 +242,11 @@ class Result {
     * _Notes:_
     *
     *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
-    *  - Returns `Result<UOkay, TError>`
+    *  - Returns `Result<UOkay, Exception|string>`
     *
     * @template UOkay
     * @param callable(TOkay):UOkay $mapFunc
-    * @return Result<UOkay, TError>
+    * @return Result<UOkay, Exception|string>
     **/
    public function mapSafely(callable $mapFunc): self {
       $either = $this->either->mapLeftSafely($mapFunc);
@@ -259,12 +261,11 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$mapFunc` must follow this interface `callable(TError):UError`
-    *  - Returns `Result<TOkay, UError>`
+    *  - `$mapFunc` must follow this interface `callable(Exception|string):Exception|string`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @template UError
-    * @param callable(TError):UError $mapFunc
-    * @return Result<TOkay, UError>
+    * @param callable(Exception|string):Exception|string $mapFunc
+    * @return Result<TOkay, Exception|string>
     **/
    public function mapError(callable $mapFunc): self {
       $either = $this->either->mapRight($mapFunc);
@@ -277,12 +278,12 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, TError>`
-    *  - Returns `Result<UOkay, TError>`
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, Exception|string>`
+    *  - Returns `Result<UOkay, Exception|string>`
     *
     * @template UOkay
-    * @param callable(TOkay):Result<UOkay, TError> $mapFunc
-    * @return Result<UOkay, TError>
+    * @param callable(TOkay):Result<UOkay, Exception|string> $mapFunc
+    * @return Result<UOkay, Exception|string>
     **/
    public function andThen(callable $mapFunc): self {
       return $this->flatMap($mapFunc);
@@ -293,15 +294,15 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, TError>`
-    *  - Returns `Result<UOkay, TError>`
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, Exception|string>`
+    *  - Returns `Result<UOkay, Exception|string>`
     *
     * @template UOkay
-    * @param callable(TOkay):Result<UOkay, TError> $mapFunc
-    * @return Result<UOkay, TError>
+    * @param callable(TOkay):Result<UOkay, Exception|string> $mapFunc
+    * @return Result<UOkay, Exception|string>
     **/
    public function flatMap(callable $mapFunc): self {
-      /** @var callable(TOkay):Either<UOkay, TError> **/
+      /** @var callable(TOkay):Either<UOkay, Exception|string> **/
       $realMap =
       /** @param TOkay $data */
       function ($data) use ($mapFunc): Either {
@@ -314,8 +315,8 @@ class Result {
    }
 
    /**
-    * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @param Exception|string $errorValue
+    * @return Result<TOkay, Exception|string>
     **/
    public function toError($errorValue): self {
       $either = $this->either->filterLeft(false, $errorValue);
@@ -324,7 +325,7 @@ class Result {
 
    /**
     * @param TOkay $dataValue
-    * @return Result<TOkay, TError>
+    * @return Result<TOkay, Exception|string>
     **/
    public function toOkay($dataValue): self {
       $either = $this->either->filterRight(false, $dataValue);
@@ -338,11 +339,11 @@ class Result {
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay):bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
     * @param callable(TOkay):bool $filterFunc
-    * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @param Exception|string $errorValue
+    * @return Result<TOkay, Exception|string>
     **/
    public function toErrorIf(callable $filterFunc, $errorValue): self {
       $either = $this->either->filterLeftIf($filterFunc, $errorValue);
@@ -355,12 +356,12 @@ class Result {
     *
     * _Notes:_
     *
-    *  - `$filterFunc` must follow this interface `callable(TError):bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - `$filterFunc` must follow this interface `callable(Exception|string):bool`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @param callable(TError):bool $filterFunc
+    * @param callable(Exception|string):bool $filterFunc
     * @param TOkay $data
-    * @return Result<TOkay, TError>
+    * @return Result<TOkay, Exception|string>
     **/
    public function toOkayIf(callable $filterFunc, $data): self {
       $either = $this->either->filterRightIf($filterFunc, $data);
@@ -372,10 +373,10 @@ class Result {
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @param Exception|string $errorValue
+    * @return Result<TOkay, Exception|string>
     **/
    public function notNull($errorValue): self {
       $either = $this->either->leftNotNull($errorValue);
@@ -387,10 +388,10 @@ class Result {
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
-    * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @param Exception|string $errorValue
+    * @return Result<TOkay, Exception|string>
     **/
    public function notFalsy($errorValue): self {
       $either = $this->either->leftNotFalsy($errorValue);
@@ -435,12 +436,12 @@ class Result {
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
     * @param TOkay $data
-    * @param TError $errorValue
+    * @param Exception|string $errorValue
     * @param callable(TOkay): bool $filterFunc
-    * @return Result<TOkay, TError>
+    * @return Result<TOkay, Exception|string>
     **/
    public static function okayWhen($data, $errorValue, callable $filterFunc): self {
       $either = Either::leftWhen($data, $errorValue, $filterFunc);
@@ -454,12 +455,12 @@ class Result {
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay, Exception|string>`
     *
     * @param TOkay $data
-    * @param TError $errorValue
+    * @param Exception|string $errorValue
     * @param callable(TOkay): bool $filterFunc
-    * @return Result<TOkay, TError>
+    * @return Result<TOkay, Exception|string>
     **/
    public static function errorWhen($data, $errorValue, callable $filterFunc): self {
       $either = Either::rightWhen($data, $errorValue, $filterFunc);
@@ -471,11 +472,11 @@ class Result {
     *
     * _Notes:_
     *
-    * - Returns `Result<TOkay, TError>`
+    * - Returns `Result<TOkay, Exception|string>`
     *
     * @param TOkay $data
-    * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @param Exception|string $errorValue
+    * @return Result<TOkay, Exception|string>
     **/
    public static function okayNotNull($data, $errorValue): self {
       $either = Either::notNullLeft($data, $errorValue);
@@ -487,12 +488,12 @@ class Result {
     *
     * _Notes:_
     *
-    * - Returns `Result<TOkay, TError>`
+    * - Returns `Result<TOkay, Exception|string>`
     *
     * @param array<array-key, mixed> $array
     * @param array-key $key The key of the array
-    * @param TError $rightValue
-    *  @return Result<TOkay, TError>
+    * @param Exception|string $rightValue
+    *  @return Result<TOkay, Exception|string>
     **/
    public static function fromArray(array $array, $key, $rightValue = null): self {
       $either = Either::fromArray($array, $key, $rightValue);

--- a/src/UnsafeResult.php
+++ b/src/UnsafeResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Optional;
+namespace Optional\Unsafe;
 
 use Optional\Either;
 
@@ -10,7 +10,7 @@ use Optional\Either;
  * @template TOkay
  * @template TError
  */
-class Result {
+class UnsafeResult {
    /** @var Either */
    private $either;
 
@@ -23,7 +23,7 @@ class Result {
 
    /**
     * @param TOkay $data
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public static function okay($data): self {
       $either = Either::left($data);
@@ -32,7 +32,7 @@ class Result {
 
    /**
     * @param TError $errorData
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public static function error($errorData): self {
       $either = Either::right($errorData);
@@ -40,21 +40,21 @@ class Result {
    }
 
    /**
-    * Returns true iff the Result is `Result::okay`
+    * Returns true iff the UnsafeResult is `UnsafeResult::okay`
     **/
    public function isOkay(): bool {
       return $this->either->isLeft();
    }
 
    /**
-    * Returns true iff the Result is `Result::error`
+    * Returns true iff the UnsafeResult is `UnsafeResult::error`
     **/
    public function isError(): bool {
       return $this->either->isRight();
    }
 
    /**
-    * Returns the Result value or returns `$alternative`
+    * Returns the UnsafeResult value or returns `$alternative`
     *
     * @param TOkay $alternative
     * @return TOkay
@@ -65,7 +65,7 @@ class Result {
    }
 
    /**
-    * Returns the Result erro value or returns `$alternative`
+    * Returns the UnsafeResult erro value or returns `$alternative`
     *
     * @param TError $alternative
     * @return TError
@@ -76,14 +76,14 @@ class Result {
    }
 
    /**
-    * Returns a `Result::okay($data)` iff the Result orginally was `Result::error($errorValue)`
+    * Returns a `UnsafeResult::okay($data)` iff the UnsafeResult orginally was `UnsafeResult::error($errorValue)`
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param TOkay $data
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function orSetDataTo($data): self {
       $either = $this->either->orLeft($data);
@@ -91,7 +91,7 @@ class Result {
    }
 
    /**
-    * Returns the Result's value or calls `$alternativeFactory` and returns the value of that function
+    * Returns the UnsafeResult's value or calls `$alternativeFactory` and returns the value of that function
     *
     * _Notes:_
     *
@@ -106,59 +106,59 @@ class Result {
    }
 
    /**
-    * Returns a `Result::okay($value)` iff the the Result orginally was `Result::error($errorValue)`
+    * Returns a `UnsafeResult::okay($value)` iff the the UnsafeResult orginally was `UnsafeResult::error($errorValue)`
     *
-    * The `$alternativeFactory` is called lazily - iff the Result orginally was `Result::error($errorValue)`
+    * The `$alternativeFactory` is called lazily - iff the UnsafeResult orginally was `UnsafeResult::error($errorValue)`
     *
     * _Notes:_
     *
     *  - `$alternativeFactory` must follow this interface `callable(TError):TOkay`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param callable(TError):TOkay $alternativeFactory
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
-   public function orCreateResultWithData(callable $alternativeFactory): self {
+   public function orCreateUnsafeResultWithData(callable $alternativeFactory): self {
       $either = $this->either->orCreateLeft($alternativeFactory);
       return new self($either);
    }
 
    /**
-    * iff `Result::error($errorValue)` return `$alternativeResult`, otherwise return the original `$result`
+    * iff `UnsafeResult::error($errorValue)` return `$alternativeUnsafeResult`, otherwise return the original `$uResult`
     *
     * _Notes:_
     *
-    *  - `$alternativeResult` must be of type `Result<TOkay, TError>`
-    *  - Returns `Result<TOkay, TError>`
+    *  - `$alternativeUnsafeResult` must be of type `UnsafeResult<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
-    * @param Result<TOkay, TError> $alternativeResult
-    * @return Result<TOkay, TError>
+    * @param UnsafeResult<TOkay, TError> $alternativeUnsafeResult
+    * @return UnsafeResult<TOkay, TError>
     **/
-   public function  okayOr(self $alternativeResult): self {
-      $either = $this->either->elseLeft($alternativeResult->either);
+   public function  okayOr(self $alternativeUnsafeResult): self {
+      $either = $this->either->elseLeft($alternativeUnsafeResult->either);
       return new self($either);
    }
 
    /**
-    * iff `Result::error` return the `Result` returned by `$alternativeResultFactory`, otherwise return the orginal `$result`
+    * iff `UnsafeResult::error` return the `UnsafeResult` returned by `$alternativeUnsafeResultFactory`, otherwise return the orginal `$uResult`
     *
-    * `$alternativeResultFactory` is run lazily
+    * `$alternativeUnsafeResultFactory` is run lazily
     *
     * _Notes:_
     *
-    *  - `$alternativeResultFactory` must be of type `callable(TError):Result<TOkay, TError> `
-    *  - Returns `Result<TOkay, TError>`
+    *  - `$alternativeUnsafeResultFactory` must be of type `callable(TError):UnsafeResult<TOkay, TError> `
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
-    * @param callable(TError):Result<TOkay, TError> $alternativeResultFactory
-    * @return Result<TOkay, TError>
+    * @param callable(TError):UnsafeResult<TOkay, TError> $alternativeUnsafeResultFactory
+    * @return UnsafeResult<TOkay, TError>
     **/
-   public function createIfError(callable $alternativeResultFactory): self {
+   public function createIfError(callable $alternativeUnsafeResultFactory): self {
       /** @var callable(TOkay):Either<TOkay, TError> **/
       $realFactory =
       /** @param TError $errorValue */
-      function ($errorValue) use ($alternativeResultFactory): Either {
-         $result = $alternativeResultFactory($errorValue);
-         return $result->either;
+      function ($errorValue) use ($alternativeUnsafeResultFactory): Either {
+         $uResult = $alternativeUnsafeResultFactory($errorValue);
+         return $uResult->either;
       };
 
       $either = $this->either->elseCreateLeft($realFactory);
@@ -168,8 +168,8 @@ class Result {
    /**
     * Runs only 1 function:
     *
-    *  - `$dataFunc` iff the Result is `Result::okay`
-    *  - `$errorFunc` iff the Result is `Result::error`
+    *  - `$dataFunc` iff the UnsafeResult is `UnsafeResult::okay`
+    *  - `$errorFunc` iff the UnsafeResult is `UnsafeResult::error`
     *
     * _Notes:_
     *
@@ -186,7 +186,7 @@ class Result {
    }
 
    /**
-    * Side effect function: Runs the function iff the Result is `Result::okay`
+    * Side effect function: Runs the function iff the UnsafeResult is `UnsafeResult::okay`
     *
     * _Notes:_
     *
@@ -199,7 +199,7 @@ class Result {
    }
 
    /**
-    * Side effect function: Runs the function iff the Result is `Result::error`
+    * Side effect function: Runs the function iff the UnsafeResult is `UnsafeResult::error`
     *
     * _Notes:_
     *
@@ -212,19 +212,19 @@ class Result {
    }
 
    /**
-    * Maps the `$value` of a `Result::okay($value)`
+    * Maps the `$value` of a `UnsafeResult::okay($value)`
     *
-    * The `map` function runs iff the Result is a `Result::okay`
-    * Otherwise the `Result:error($errorValue)` is propagated
+    * The `map` function runs iff the UnsafeResult is a `UnsafeResult::okay`
+    * Otherwise the `UnsafeResult:error($errorValue)` is propagated
     *
     * _Notes:_
     *
     *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
-    *  - Returns `Result<UOkay, TError>`
+    *  - Returns `UnsafeResult<UOkay, TError>`
     *
     * @template UOkay
     * @param callable(TOkay):UOkay $mapFunc
-    * @return Result<UOkay, TError>
+    * @return UnsafeResult<UOkay, TError>
     **/
    public function map(callable $mapFunc): self {
       $either = $this->either->mapLeft($mapFunc);
@@ -232,19 +232,19 @@ class Result {
    }
 
    /**
-    * `map`, but if an exception occurs, return `Result::error(exception)`
+    * `map`, but if an exception occurs, return `UnsafeResult::error(exception)`
     *
-    * The `map` function runs iff the Result is a `Result::okay`
-    * Otherwise the `Result:error($errorValue)` is propagated
+    * The `map` function runs iff the UnsafeResult is a `UnsafeResult::okay`
+    * Otherwise the `UnsafeResult:error($errorValue)` is propagated
     *
     * _Notes:_
     *
     *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
-    *  - Returns `Result<UOkay, TError>`
+    *  - Returns `UnsafeResult<UOkay, TError>`
     *
     * @template UOkay
     * @param callable(TOkay):UOkay $mapFunc
-    * @return Result<UOkay, TError>
+    * @return UnsafeResult<UOkay, TError>
     **/
    public function mapSafely(callable $mapFunc): self {
       $either = $this->either->mapLeftSafely($mapFunc);
@@ -252,19 +252,19 @@ class Result {
    }
 
    /**
-    * Maps the `$value` of a `Result::error($errorValue)`
+    * Maps the `$value` of a `UnsafeResult::error($errorValue)`
     *
-    * The `map` function runs iff the Result is a `Result::error`
-    * Otherwise the `Result:okay($data)` is propagated
+    * The `map` function runs iff the UnsafeResult is a `UnsafeResult::error`
+    * Otherwise the `UnsafeResult:okay($data)` is propagated
     *
     * _Notes:_
     *
     *  - `$mapFunc` must follow this interface `callable(TError):UError`
-    *  - Returns `Result<TOkay, UError>`
+    *  - Returns `UnsafeResult<TOkay, UError>`
     *
     * @template UError
     * @param callable(TError):UError $mapFunc
-    * @return Result<TOkay, UError>
+    * @return UnsafeResult<TOkay, UError>
     **/
    public function mapError(callable $mapFunc): self {
       $either = $this->either->mapRight($mapFunc);
@@ -273,40 +273,40 @@ class Result {
 
    /**
     * A copy of flatMapData
-    * Allows a function to map over the internal value, the function returns an Result
+    * Allows a function to map over the internal value, the function returns an UnsafeResult
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, TError>`
-    *  - Returns `Result<UOkay, TError>`
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):UnsafeResult<UOkay, TError>`
+    *  - Returns `UnsafeResult<UOkay, TError>`
     *
     * @template UOkay
-    * @param callable(TOkay):Result<UOkay, TError> $mapFunc
-    * @return Result<UOkay, TError>
+    * @param callable(TOkay):UnsafeResult<UOkay, TError> $mapFunc
+    * @return UnsafeResult<UOkay, TError>
     **/
    public function andThen(callable $mapFunc): self {
       return $this->flatMap($mapFunc);
    }
 
    /**
-    * Allows a function to map over the internal value, the function returns an Result
+    * Allows a function to map over the internal value, the function returns an UnsafeResult
     *
     * _Notes:_
     *
-    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, TError>`
-    *  - Returns `Result<UOkay, TError>`
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):UnsafeResult<UOkay, TError>`
+    *  - Returns `UnsafeResult<UOkay, TError>`
     *
     * @template UOkay
-    * @param callable(TOkay):Result<UOkay, TError> $mapFunc
-    * @return Result<UOkay, TError>
+    * @param callable(TOkay):UnsafeResult<UOkay, TError> $mapFunc
+    * @return UnsafeResult<UOkay, TError>
     **/
    public function flatMap(callable $mapFunc): self {
       /** @var callable(TOkay):Either<UOkay, TError> **/
       $realMap =
       /** @param TOkay $data */
       function ($data) use ($mapFunc): Either {
-         $result = $mapFunc($data);
-         return $result->either;
+         $uResult = $mapFunc($data);
+         return $uResult->either;
       };
 
       $either = $this->either->flatMapLeft($realMap);
@@ -315,7 +315,7 @@ class Result {
 
    /**
     * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function toError($errorValue): self {
       $either = $this->either->filterLeft(false, $errorValue);
@@ -324,7 +324,7 @@ class Result {
 
    /**
     * @param TOkay $dataValue
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function toOkay($dataValue): self {
       $either = $this->either->filterRight(false, $dataValue);
@@ -332,17 +332,17 @@ class Result {
    }
 
    /**
-    * Change the `Result::okay($value)` into `Result::error($errorValue)` iff `$filterFunc` returns false,
-    * otherwise propigate the `Result::error()`
+    * Change the `UnsafeResult::okay($value)` into `UnsafeResult::error($errorValue)` iff `$filterFunc` returns false,
+    * otherwise propigate the `UnsafeResult::error()`
     *
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay):bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param callable(TOkay):bool $filterFunc
     * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function toErrorIf(callable $filterFunc, $errorValue): self {
       $either = $this->either->filterLeftIf($filterFunc, $errorValue);
@@ -350,17 +350,17 @@ class Result {
    }
 
    /**
-    * Change the `Result::error($errorValue)` into `Result::okay($data)` iff `$filterFunc` returns false,
-    * otherwise propigate the `Result::okay()`
+    * Change the `UnsafeResult::error($errorValue)` into `UnsafeResult::okay($data)` iff `$filterFunc` returns false,
+    * otherwise propigate the `UnsafeResult::okay()`
     *
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TError):bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param callable(TError):bool $filterFunc
     * @param TOkay $data
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function toOkayIf(callable $filterFunc, $data): self {
       $either = $this->either->filterRightIf($filterFunc, $data);
@@ -368,14 +368,14 @@ class Result {
    }
 
    /**
-    * Turn an `Result::okay(null)` into an `Result::error($errorValue)` iff `is_null($value)`
+    * Turn an `UnsafeResult::okay(null)` into an `UnsafeResult::error($errorValue)` iff `is_null($value)`
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function notNull($errorValue): self {
       $either = $this->either->leftNotNull($errorValue);
@@ -383,14 +383,14 @@ class Result {
    }
 
    /**
-    * Turn an `Result::okay($value)` into an `Result::error($errorValue)` iff `!$value == true`
+    * Turn an `UnsafeResult::okay($value)` into an `UnsafeResult::error($errorValue)` iff `!$value == true`
     *
     * _Notes:_
     *
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public function notFalsy($errorValue): self {
       $either = $this->either->leftNotFalsy($errorValue);
@@ -398,7 +398,7 @@ class Result {
    }
 
    /**
-    * Returns true if the Result's data == `$value`, otherwise false.
+    * Returns true if the UnsafeResult's data == `$value`, otherwise false.
     *
     * @param mixed $value
     **/
@@ -407,7 +407,7 @@ class Result {
    }
 
    /**
-    * Returns true if the Result's error == `$value`, otherwise false.
+    * Returns true if the UnsafeResult's error == `$value`, otherwise false.
     *
     * @param mixed $value
     **/
@@ -429,18 +429,18 @@ class Result {
    }
 
    /**
-    * Take a value, turn it a `Result::okay($data)` iff the `$filterFunc` returns true
-    * otherwise an `Result::error($errorValue)`
+    * Take a value, turn it a `UnsafeResult::okay($data)` iff the `$filterFunc` returns true
+    * otherwise an `UnsafeResult::error($errorValue)`
     *
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param TOkay $data
     * @param TError $errorValue
     * @param callable(TOkay): bool $filterFunc
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public static function okayWhen($data, $errorValue, callable $filterFunc): self {
       $either = Either::leftWhen($data, $errorValue, $filterFunc);
@@ -448,18 +448,18 @@ class Result {
    }
 
    /**
-    * Take a value, turn it a `Result::error($errorValue)` iff the `$filterFunc` returns true
-    * otherwise an `Result::okay($data)`
+    * Take a value, turn it a `UnsafeResult::error($errorValue)` iff the `$filterFunc` returns true
+    * otherwise an `UnsafeResult::okay($data)`
     *
     * _Notes:_
     *
     *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
-    *  - Returns `Result<TOkay, TError>`
+    *  - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param TOkay $data
     * @param TError $errorValue
     * @param callable(TOkay): bool $filterFunc
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public static function errorWhen($data, $errorValue, callable $filterFunc): self {
       $either = Either::rightWhen($data, $errorValue, $filterFunc);
@@ -467,15 +467,15 @@ class Result {
    }
 
    /**
-    * Take a value, turn it a `Result::okay($data)` iff `!is_null($data)`, otherwise returns `Result::error($errorValue)`
+    * Take a value, turn it a `UnsafeResult::okay($data)` iff `!is_null($data)`, otherwise returns `UnsafeResult::error($errorValue)`
     *
     * _Notes:_
     *
-    * - Returns `Result<TOkay, TError>`
+    * - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param TOkay $data
     * @param TError $errorValue
-    * @return Result<TOkay, TError>
+    * @return UnsafeResult<TOkay, TError>
     **/
    public static function okayNotNull($data, $errorValue): self {
       $either = Either::notNullLeft($data, $errorValue);
@@ -483,16 +483,16 @@ class Result {
    }
 
    /**
-    * Creates a Result if the `$key` exists in `$array`
+    * Creates a UnsafeResult if the `$key` exists in `$array`
     *
     * _Notes:_
     *
-    * - Returns `Result<TOkay, TError>`
+    * - Returns `UnsafeResult<TOkay, TError>`
     *
     * @param array<array-key, mixed> $array
     * @param array-key $key The key of the array
     * @param TError $rightValue
-    *  @return Result<TOkay, TError>
+    *  @return UnsafeResult<TOkay, TError>
     **/
    public static function fromArray(array $array, $key, $rightValue = null): self {
       $either = Either::fromArray($array, $key, $rightValue);

--- a/src/UnsafeResult.php
+++ b/src/UnsafeResult.php
@@ -1,0 +1,501 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Optional;
+
+use Optional\Either;
+
+/**
+ * @template TOkay
+ * @template TError
+ */
+class Result {
+   /** @var Either */
+   private $either;
+
+   /**
+    * @param Either $either
+    **/
+    private function __construct(Either $either) {
+      $this->either = $either;
+   }
+
+   /**
+    * @param TOkay $data
+    * @return Result<TOkay, TError>
+    **/
+   public static function okay($data): self {
+      $either = Either::left($data);
+      return new self($either);
+   }
+
+   /**
+    * @param TError $errorData
+    * @return Result<TOkay, TError>
+    **/
+   public static function error($errorData): self {
+      $either = Either::right($errorData);
+      return new self($either);
+   }
+
+   /**
+    * Returns true iff the Result is `Result::okay`
+    **/
+   public function isOkay(): bool {
+      return $this->either->isLeft();
+   }
+
+   /**
+    * Returns true iff the Result is `Result::error`
+    **/
+   public function isError(): bool {
+      return $this->either->isRight();
+   }
+
+   /**
+    * Returns the Result value or returns `$alternative`
+    *
+    * @param TOkay $alternative
+    * @return TOkay
+    **/
+   public function dataOr($alternative) {
+      /** @var TOkay **/
+      return $this->either->leftOr($alternative);
+   }
+
+   /**
+    * Returns the Result erro value or returns `$alternative`
+    *
+    * @param TError $alternative
+    * @return TError
+    **/
+   public function errorOr($alternative) {
+      /** @var TError **/
+      return $this->either->rightOr($alternative);
+   }
+
+   /**
+    * Returns a `Result::okay($data)` iff the Result orginally was `Result::error($errorValue)`
+    *
+    * _Notes:_
+    *
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param TOkay $data
+    * @return Result<TOkay, TError>
+    **/
+   public function orSetDataTo($data): self {
+      $either = $this->either->orLeft($data);
+      return new self($either);
+   }
+
+   /**
+    * Returns the Result's value or calls `$alternativeFactory` and returns the value of that function
+    *
+    * _Notes:_
+    *
+    *  - `$alternativeFactory` must follow this interface `callable(TError):TOkay`
+    *
+    * @param callable(TError):TOkay $alternativeFactory
+    * @return TOkay
+    **/
+   public function dataOrReturn(callable $alternativeFactory) {
+      /** @var TOkay **/
+      return $this->either->leftOrCreate($alternativeFactory);
+   }
+
+   /**
+    * Returns a `Result::okay($value)` iff the the Result orginally was `Result::error($errorValue)`
+    *
+    * The `$alternativeFactory` is called lazily - iff the Result orginally was `Result::error($errorValue)`
+    *
+    * _Notes:_
+    *
+    *  - `$alternativeFactory` must follow this interface `callable(TError):TOkay`
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param callable(TError):TOkay $alternativeFactory
+    * @return Result<TOkay, TError>
+    **/
+   public function orCreateResultWithData(callable $alternativeFactory): self {
+      $either = $this->either->orCreateLeft($alternativeFactory);
+      return new self($either);
+   }
+
+   /**
+    * iff `Result::error($errorValue)` return `$alternativeResult`, otherwise return the original `$result`
+    *
+    * _Notes:_
+    *
+    *  - `$alternativeResult` must be of type `Result<TOkay, TError>`
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param Result<TOkay, TError> $alternativeResult
+    * @return Result<TOkay, TError>
+    **/
+   public function  okayOr(self $alternativeResult): self {
+      $either = $this->either->elseLeft($alternativeResult->either);
+      return new self($either);
+   }
+
+   /**
+    * iff `Result::error` return the `Result` returned by `$alternativeResultFactory`, otherwise return the orginal `$result`
+    *
+    * `$alternativeResultFactory` is run lazily
+    *
+    * _Notes:_
+    *
+    *  - `$alternativeResultFactory` must be of type `callable(TError):Result<TOkay, TError> `
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param callable(TError):Result<TOkay, TError> $alternativeResultFactory
+    * @return Result<TOkay, TError>
+    **/
+   public function createIfError(callable $alternativeResultFactory): self {
+      /** @var callable(TOkay):Either<TOkay, TError> **/
+      $realFactory =
+      /** @param TError $errorValue */
+      function ($errorValue) use ($alternativeResultFactory): Either {
+         $result = $alternativeResultFactory($errorValue);
+         return $result->either;
+      };
+
+      $either = $this->either->elseCreateLeft($realFactory);
+      return new self($either);
+   }
+
+   /**
+    * Runs only 1 function:
+    *
+    *  - `$dataFunc` iff the Result is `Result::okay`
+    *  - `$errorFunc` iff the Result is `Result::error`
+    *
+    * _Notes:_
+    *
+    *  - `$dataFunc` must follow this interface `callable(TOkay):U`
+    *  - `$errorFunc` must follow this interface `callable(TError):U`
+    *
+    * @template U
+    * @param callable(TOkay):U $dataFunc
+    * @param callable(TError):U $errorFunc
+    * @return U
+    **/
+   public function run(callable $dataFunc, callable $errorFunc) {
+      return $this->either->match($dataFunc, $errorFunc);
+   }
+
+   /**
+    * Side effect function: Runs the function iff the Result is `Result::okay`
+    *
+    * _Notes:_
+    *
+    *  - `$dataFunc` must follow this interface `callable(TOkay):U`
+    *
+    * @param callable(TOkay) $dataFunc
+    **/
+   public function runOnOkay(callable $dataFunc): void {
+      $this->either->matchLeft($dataFunc);
+   }
+
+   /**
+    * Side effect function: Runs the function iff the Result is `Result::error`
+    *
+    * _Notes:_
+    *
+    *  - `$errorFunc` must follow this interface `callable(TError):U`
+    *
+    * @param callable(TError) $errorFunc
+    **/
+   public function runOnError(callable $errorFunc): void {
+      $this->either->matchRight($errorFunc);
+   }
+
+   /**
+    * Maps the `$value` of a `Result::okay($value)`
+    *
+    * The `map` function runs iff the Result is a `Result::okay`
+    * Otherwise the `Result:error($errorValue)` is propagated
+    *
+    * _Notes:_
+    *
+    *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
+    *  - Returns `Result<UOkay, TError>`
+    *
+    * @template UOkay
+    * @param callable(TOkay):UOkay $mapFunc
+    * @return Result<UOkay, TError>
+    **/
+   public function map(callable $mapFunc): self {
+      $either = $this->either->mapLeft($mapFunc);
+      return new self($either);
+   }
+
+   /**
+    * `map`, but if an exception occurs, return `Result::error(exception)`
+    *
+    * The `map` function runs iff the Result is a `Result::okay`
+    * Otherwise the `Result:error($errorValue)` is propagated
+    *
+    * _Notes:_
+    *
+    *  - `$mapFunc` must follow this interface `callable(TOkay):UOkay`
+    *  - Returns `Result<UOkay, TError>`
+    *
+    * @template UOkay
+    * @param callable(TOkay):UOkay $mapFunc
+    * @return Result<UOkay, TError>
+    **/
+   public function mapSafely(callable $mapFunc): self {
+      $either = $this->either->mapLeftSafely($mapFunc);
+      return new self($either);
+   }
+
+   /**
+    * Maps the `$value` of a `Result::error($errorValue)`
+    *
+    * The `map` function runs iff the Result is a `Result::error`
+    * Otherwise the `Result:okay($data)` is propagated
+    *
+    * _Notes:_
+    *
+    *  - `$mapFunc` must follow this interface `callable(TError):UError`
+    *  - Returns `Result<TOkay, UError>`
+    *
+    * @template UError
+    * @param callable(TError):UError $mapFunc
+    * @return Result<TOkay, UError>
+    **/
+   public function mapError(callable $mapFunc): self {
+      $either = $this->either->mapRight($mapFunc);
+      return new self($either);
+   }
+
+   /**
+    * A copy of flatMapData
+    * Allows a function to map over the internal value, the function returns an Result
+    *
+    * _Notes:_
+    *
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, TError>`
+    *  - Returns `Result<UOkay, TError>`
+    *
+    * @template UOkay
+    * @param callable(TOkay):Result<UOkay, TError> $mapFunc
+    * @return Result<UOkay, TError>
+    **/
+   public function andThen(callable $mapFunc): self {
+      return $this->flatMap($mapFunc);
+   }
+
+   /**
+    * Allows a function to map over the internal value, the function returns an Result
+    *
+    * _Notes:_
+    *
+    *  - `$alternativeFactory` must follow this interface `callable(TOkay):Result<UOkay, TError>`
+    *  - Returns `Result<UOkay, TError>`
+    *
+    * @template UOkay
+    * @param callable(TOkay):Result<UOkay, TError> $mapFunc
+    * @return Result<UOkay, TError>
+    **/
+   public function flatMap(callable $mapFunc): self {
+      /** @var callable(TOkay):Either<UOkay, TError> **/
+      $realMap =
+      /** @param TOkay $data */
+      function ($data) use ($mapFunc): Either {
+         $result = $mapFunc($data);
+         return $result->either;
+      };
+
+      $either = $this->either->flatMapLeft($realMap);
+      return new self($either);
+   }
+
+   /**
+    * @param TError $errorValue
+    * @return Result<TOkay, TError>
+    **/
+   public function toError($errorValue): self {
+      $either = $this->either->filterLeft(false, $errorValue);
+      return new self($either);
+   }
+
+   /**
+    * @param TOkay $dataValue
+    * @return Result<TOkay, TError>
+    **/
+   public function toOkay($dataValue): self {
+      $either = $this->either->filterRight(false, $dataValue);
+      return new self($either);
+   }
+
+   /**
+    * Change the `Result::okay($value)` into `Result::error($errorValue)` iff `$filterFunc` returns false,
+    * otherwise propigate the `Result::error()`
+    *
+    * _Notes:_
+    *
+    *  - `$filterFunc` must follow this interface `callable(TOkay):bool`
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param callable(TOkay):bool $filterFunc
+    * @param TError $errorValue
+    * @return Result<TOkay, TError>
+    **/
+   public function toErrorIf(callable $filterFunc, $errorValue): self {
+      $either = $this->either->filterLeftIf($filterFunc, $errorValue);
+      return new self($either);
+   }
+
+   /**
+    * Change the `Result::error($errorValue)` into `Result::okay($data)` iff `$filterFunc` returns false,
+    * otherwise propigate the `Result::okay()`
+    *
+    * _Notes:_
+    *
+    *  - `$filterFunc` must follow this interface `callable(TError):bool`
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param callable(TError):bool $filterFunc
+    * @param TOkay $data
+    * @return Result<TOkay, TError>
+    **/
+   public function toOkayIf(callable $filterFunc, $data): self {
+      $either = $this->either->filterRightIf($filterFunc, $data);
+      return new self($either);
+   }
+
+   /**
+    * Turn an `Result::okay(null)` into an `Result::error($errorValue)` iff `is_null($value)`
+    *
+    * _Notes:_
+    *
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param TError $errorValue
+    * @return Result<TOkay, TError>
+    **/
+   public function notNull($errorValue): self {
+      $either = $this->either->leftNotNull($errorValue);
+      return new self($either);
+   }
+
+   /**
+    * Turn an `Result::okay($value)` into an `Result::error($errorValue)` iff `!$value == true`
+    *
+    * _Notes:_
+    *
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param TError $errorValue
+    * @return Result<TOkay, TError>
+    **/
+   public function notFalsy($errorValue): self {
+      $either = $this->either->leftNotFalsy($errorValue);
+      return new self($either);
+   }
+
+   /**
+    * Returns true if the Result's data == `$value`, otherwise false.
+    *
+    * @param mixed $value
+    **/
+   public function contains($value): bool {
+      return $this->either->leftContains($value);
+   }
+
+   /**
+    * Returns true if the Result's error == `$value`, otherwise false.
+    *
+    * @param mixed $value
+    **/
+   public function errorContains($value): bool {
+      return $this->either->rightContains($value);
+   }
+
+    /**
+    * Returns true if the `$existsFunc` returns true, otherwise false.
+    *
+    * _Notes:_
+    *
+    *  - `$filterFunc` must follow this interface `callable(TOkay):bool`
+    *
+    * @param callable(TOkay):bool $existsFunc
+    **/
+   public function exists(callable $existsFunc): bool {
+      return $this->either->existsLeft($existsFunc);
+   }
+
+   /**
+    * Take a value, turn it a `Result::okay($data)` iff the `$filterFunc` returns true
+    * otherwise an `Result::error($errorValue)`
+    *
+    * _Notes:_
+    *
+    *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param TOkay $data
+    * @param TError $errorValue
+    * @param callable(TOkay): bool $filterFunc
+    * @return Result<TOkay, TError>
+    **/
+   public static function okayWhen($data, $errorValue, callable $filterFunc): self {
+      $either = Either::leftWhen($data, $errorValue, $filterFunc);
+      return new self($either);
+   }
+
+   /**
+    * Take a value, turn it a `Result::error($errorValue)` iff the `$filterFunc` returns true
+    * otherwise an `Result::okay($data)`
+    *
+    * _Notes:_
+    *
+    *  - `$filterFunc` must follow this interface `callable(TOkay): bool`
+    *  - Returns `Result<TOkay, TError>`
+    *
+    * @param TOkay $data
+    * @param TError $errorValue
+    * @param callable(TOkay): bool $filterFunc
+    * @return Result<TOkay, TError>
+    **/
+   public static function errorWhen($data, $errorValue, callable $filterFunc): self {
+      $either = Either::rightWhen($data, $errorValue, $filterFunc);
+      return new self($either);
+   }
+
+   /**
+    * Take a value, turn it a `Result::okay($data)` iff `!is_null($data)`, otherwise returns `Result::error($errorValue)`
+    *
+    * _Notes:_
+    *
+    * - Returns `Result<TOkay, TError>`
+    *
+    * @param TOkay $data
+    * @param TError $errorValue
+    * @return Result<TOkay, TError>
+    **/
+   public static function okayNotNull($data, $errorValue): self {
+      $either = Either::notNullLeft($data, $errorValue);
+      return new self($either);
+   }
+
+   /**
+    * Creates a Result if the `$key` exists in `$array`
+    *
+    * _Notes:_
+    *
+    * - Returns `Result<TOkay, TError>`
+    *
+    * @param array<array-key, mixed> $array
+    * @param array-key $key The key of the array
+    * @param TError $rightValue
+    *  @return Result<TOkay, TError>
+    **/
+   public static function fromArray(array $array, $key, $rightValue = null): self {
+      $either = Either::fromArray($array, $key, $rightValue);
+      return new self($either);
+   }
+}

--- a/src/UnsafeResult.php
+++ b/src/UnsafeResult.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Optional\Unsafe;
+namespace Optional;
 
 use Optional\Either;
 
@@ -118,7 +118,7 @@ class UnsafeResult {
     * @param callable(TError):TOkay $alternativeFactory
     * @return UnsafeResult<TOkay, TError>
     **/
-   public function orCreateUnsafeResultWithData(callable $alternativeFactory): self {
+   public function orCreateResultWithData(callable $alternativeFactory): self {
       $either = $this->either->orCreateLeft($alternativeFactory);
       return new self($either);
    }

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -70,31 +70,6 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $this->assertSame($okayClass->dataOrThrow(), $someObject);
    }
 
-   public function testGettingValueLazily() {
-      $errorValue = new \Exception("Oh no!");
-      $errorResult = Result::error($errorValue);
-
-      $this->assertSame($errorResult->dataOrReturn(function($x) { return $x; }), $errorValue);
-
-      $someObject = new SomeObject();
-
-      $okayThing = Result::okay(1);
-      $okayClass = Result::okay($someObject);
-
-      $this->assertSame($okayThing->dataOrReturn(function($x) { return $x; }), 1);
-      $this->assertSame($okayClass->dataOrReturn(function($x) { return $x; }), $someObject);
-
-      $this->assertSame($okayThing->dataOrReturn(function($x) {
-         $this->fail('Callback should not have been run!');
-         return $x;
-      }), 1);
-
-      $this->assertSame($okayClass->dataOrReturn(function($x) {
-         $this->fail('Callback should not have been run!');
-         return $x;
-      }), $someObject);
-   }
-
    public function testGettingAlternitiveValue() {
       $errorValue = new \Exception("Oh no!");
       $someObject = new SomeObject();

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -7,7 +7,7 @@ use Optional\Result;
 
 class ResultTest extends PHPUnit\Framework\TestCase {
    public function testCreateAndCheckExistence() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $errorResult = Result::error($errorValue);
 
       $this->assertFalse($errorResult->isOkay());
@@ -24,18 +24,16 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $this->assertFalse($okayNullable->isError());
       $this->assertFalse($okayClass->isError());
 
-      $noname = Result::fromArray(['name' => 'value'], 'noname', 'oh no');
+      $noname = Result::fromArray(['name' => 'value'], 'noname', new \Exception('oh no'));
       $this->assertTrue($noname->isError());
       $this->assertFalse($noname->isOkay());
 
-      $name = Result::fromArray(['name' => 'value'], 'name', 'oh no');
+      $name = Result::fromArray(['name' => 'value'], 'name', new \Exception('oh no'));
       $this->assertTrue($name->isOkay());
       $this->assertFalse($name->isError());
 
-      $nonameResult = Result::fromArray(['name' => 'value'], 'noname');
-      $nonameNull = Result::fromArray(['name' => 'value'], 'noname');
-      $this->assertFalse($nonameResult->isOkay());
-      $this->assertFalse($nonameNull->isOkay());
+      $nonameNull = Result::fromArray(['name' => 'value'], 'missing', new \Exception('noname'));
+      $this->assertTrue($nonameNull->isError());
 
       $error = Result::okayNotNull(null, $errorValue);
       $okay = Result::okayNotNull('', $errorValue);
@@ -45,7 +43,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testCreateAndCheckExistenceWhen() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
 
       $okayThing = Result::okayWhen(1, $errorValue, function($x) { return $x > 0; });
       $okayThing2 = Result::okayWhen(-1, $errorValue, function($x) { return $x > 0; });
@@ -58,13 +56,10 @@ class ResultTest extends PHPUnit\Framework\TestCase {
 
       $this->assertSame($okayThing3->dataOr(-5), -5);
       $this->assertSame($okayThing4->dataOr(-5), -1);
-
-      $errorThing = Result::errorWhen(1, 100, function($x) { return $x > 0; });
-      $errorThing2 = Result::errorWhen(-1, 100, function($x) { return $x > 0; });
    }
 
    public function testGettingValue() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $errorResult = Result::error($errorValue);
 
       $this->assertSame($errorResult->dataOr(-1), -1);
@@ -79,7 +74,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testGettingValueLazily() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $errorResult = Result::error($errorValue);
 
       $this->assertSame($errorResult->dataOrReturn(function($x) { return $x; }), $errorValue);
@@ -104,7 +99,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testGettingAlternitiveValue() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $someObject = new SomeObject();
       $errorResult = Result::error($errorValue);
 
@@ -129,7 +124,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testGettingAlternitiveResult() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $someObject = new SomeObject();
       $errorResult = Result::error($errorValue);
 
@@ -149,7 +144,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testGettingAlternitiveResultLazy() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $someObject = new SomeObject();
       $errorResult = Result::error($errorValue);
 
@@ -185,7 +180,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testMatching() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $error = Result::error($errorValue);
       $okay = Result::okay(1);
 
@@ -230,7 +225,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testMapping() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $error = Result::error($errorValue);
       $okay = Result::okay("a");
       $okayNull = Result::okay(null);
@@ -243,7 +238,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $this->assertSame($errorUpper->dataOr("b"), "b");
       $this->assertSame($okayUpper->dataOr("b"), "A");
 
-      $error = Result::error("a");
+      $error = Result::error(new \Exception("a"));
       $okay = Result::okay("a");
       $okayNull = Result::okay(null);
 
@@ -255,17 +250,15 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $this->assertTrue($notNull->isOkay());
       $this->assertFalse($okayNullNotNull->isOkay());
 
-      $errorUpper = $error->mapError(function($x) { return strtoupper($x); });
+      $errorUpper = $error->mapError(function($x) { return new \Exception(strtoupper($x->getMessage())); });
       $okayUpper = $okay->mapError(function($x) { return strtoupper($x); });
 
       $this->assertFalse($errorUpper->isOkay());
       $this->assertTrue($okayUpper->isOkay());
-      $this->assertSame($errorUpper->errorOr("b"), "A");
-      $this->assertSame($okayUpper->errorOr("b"), "b");
    }
 
    public function testFiltering() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $error = Result::error($errorValue);
       $okay = Result::okay("a");
 
@@ -301,7 +294,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    }
 
    public function testContains() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $error = Result::error($errorValue);
       $okayString = Result::okay("a");
       $okayInt = Result::okay(1);
@@ -316,27 +309,15 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $this->assertFalse($okayInt->contains("A"));
       $this->assertFalse($okayInt->contains(null));
 
+      $this->assertTrue($error->errorContains($errorValue));
       $this->assertFalse($error->contains(1));
       $this->assertFalse($error->contains(2));
       $this->assertFalse($error->contains("A"));
       $this->assertFalse($error->contains(null));
-
-      $errorString = Result::error("a");
-      $errorInt = Result::error(1);
-
-      $this->assertTrue($errorString->errorContains("a"));
-      $this->assertFalse($errorString->errorContains("A"));
-      $this->assertFalse($errorString->errorContains(1));
-      $this->assertFalse($errorString->errorContains(null));
-
-      $this->assertTrue($errorInt->errorContains(1));
-      $this->assertFalse($error->errorContains(2));
-      $this->assertFalse($error->errorContains("A"));
-      $this->assertFalse($error->errorContains(null));
    }
 
    public function testExists() {
-      $errorValue = "goodbye";
+      $errorValue = new \Exception("Oh no!");
       $error = Result::error($errorValue);
       $okay = Result::okay(10);
 
@@ -357,7 +338,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
          ]
       ];
 
-      $person = Result::fromArray($okayPerson, 'name', 'name was missing');
+      $person = Result::fromArray($okayPerson, 'name', new \Exception('name was missing'));
 
       $name = $person->andThen(function($person) {
          $fullName = $person['first'] . $person['last'];
@@ -382,7 +363,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
          ]
       ];
 
-      $person = Result::fromArray($okayPerson, 'name', 'name was missing');
+      $person = Result::fromArray($okayPerson, 'name', new \Exception('name was missing'));
 
       $name = $person->andThen(function($person) {
          $fullName = $person['first'] . $person['last'];
@@ -390,7 +371,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
          try {
             $thing = SomeComplexThing::doWork($fullName, "Forcing exception");
          } catch (\Exception $e) {
-            return Result::error('SomeComplexThing had an error!');
+            return Result::error(new \Exception('SomeComplexThing had an error!'));
          }
 
          return Result::okay($thing);
@@ -408,7 +389,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
          ]
       ];
 
-      $person = Result::fromArray($okayPerson, 'name', 'name was missing');
+      $person = Result::fromArray($okayPerson, 'name', new \Exception('name was missing'));
 
       $name = $person->map(function($person): string {
          $fullName = $person['first'] . $person['last'];
@@ -431,7 +412,9 @@ class ResultTest extends PHPUnit\Framework\TestCase {
    public function testExceptionToErrorState() {
       $lazyThrow = function() { throw new \Exception("Forced Exception!"); };
       $okay = Result::okay("It's Okay!");
-      $error = Result::error("Error!");
+
+      $errorValue = new \Exception("Oh no!");
+      $error = Result::error($errorValue);
 
       $after = $error->orCreateResultWithData($lazyThrow);
       $this->assertTrue($after->isError());
@@ -457,10 +440,10 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $after = $error->toOkayIf($lazyThrow, new \Exception("Another Exception"));
       $this->assertTrue($after->isError());
 
-      $after = Result::okayWhen("Okay", "Error", $lazyThrow);
+      $after = Result::okayWhen("Okay", $errorValue, $lazyThrow);
       $this->assertTrue($after->isError());
 
-      $after = Result::errorWhen("Okay", "Error", $lazyThrow);
+      $after = Result::errorWhen("Okay", $errorValue, $lazyThrow);
       $this->assertTrue($after->isError());
 
       try {

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -338,20 +338,14 @@ class ResultTest extends PHPUnit\Framework\TestCase {
 
       $name = $person->andThen(function($person) {
          $fullName = $person['first'] . $person['last'];
-
-         try {
-            $thing = SomeComplexThing::doWork($fullName);
-         } catch (ErrorException $e) {
-            return Result::error('SomeComplexThing had an error!');
-         }
-
+         $thing = SomeComplexThing::doWork($fullName);
          return Result::okay($thing);
       });
 
       $this->assertSame($name->dataOrThrow(), 'FirstLast');
    }
 
-   public function testFlatMapWithException() {
+   public function testFlatMapWithThrowable() {
       $okayPerson = [
          'name' => [
             'first' => 'First',
@@ -363,13 +357,7 @@ class ResultTest extends PHPUnit\Framework\TestCase {
 
       $name = $person->andThen(function($person) {
          $fullName = $person['first'] . $person['last'];
-
-         try {
-            $thing = SomeComplexThing::doWork($fullName, "Forcing exception");
-         } catch (\Exception $e) {
-            return Result::error(new \Exception('SomeComplexThing had an error!'));
-         }
-
+         $thing = SomeComplexThing::doWork($fullName, "Forcing Throwable");
          return Result::okay($thing);
       });
 
@@ -377,11 +365,11 @@ class ResultTest extends PHPUnit\Framework\TestCase {
 
       try {
          $data = $name->dataOrThrow();
-         $this->fail("Expected to throw exception");
-      } catch (\Exception $e) {}
+         $this->fail("Expected to throw Exception");
+      } catch (\Throwable $e) {}
    }
 
-   public function testSafelyMapWithException() {
+   public function testSafelyMapWithThrowable() {
       $okayPerson = [
          'name' => [
             'first' => 'First',
@@ -393,28 +381,28 @@ class ResultTest extends PHPUnit\Framework\TestCase {
 
       $name = $person->map(function($person): string {
          $fullName = $person['first'] . $person['last'];
-         return SomeComplexThing::doWork($fullName, "Forcing exception");
+         return SomeComplexThing::doWork($fullName, "Forcing Throwable");
       });
 
       $this->assertFalse($name->isOkay());
 
       try {
          $data = $name->dataOrThrow();
-         $this->fail("Expected to throw exception");
-      } catch (\Exception $e) {}
+         $this->fail("Expected to throw Exception");
+      } catch (\Throwable $e) {}
 
       $out = 'This should change';
 
       $name->run(
          function ($okayValue) { $this->fail('Callback should not have been run!'); },
-         function ($exception) use(&$out) { $out = $exception->getMessage(); }
+         function ($Throwable) use(&$out) { $out = $Throwable->getMessage(); }
       );
 
-      $this->assertSame($out, "Forcing exception");
+      $this->assertSame($out, "Forcing Throwable");
    }
 
-   public function testExceptionToErrorState() {
-      $lazyThrow = function() { throw new \Exception("Forced Exception!"); };
+   public function testThrowableToErrorState() {
+      $lazyThrow = function() { throw new \Exception("Forced Throwable!"); };
       $okay = Result::okay("It's Okay!");
 
       $errorValue = new \Exception("Oh no!");
@@ -438,10 +426,10 @@ class ResultTest extends PHPUnit\Framework\TestCase {
       $after = $okay->flatMap($lazyThrow);
       $this->assertTrue($after->isError());
 
-      $after = $okay->toErrorIf($lazyThrow, new \Exception("Another Exception"));
+      $after = $okay->toErrorIf($lazyThrow, new \Exception("Another Throwable"));
       $this->assertTrue($after->isError());
 
-      $after = $error->toOkayIf($lazyThrow, new \Exception("Another Exception"));
+      $after = $error->toOkayIf($lazyThrow, new \Exception("Another Throwable"));
       $this->assertTrue($after->isError());
 
       $after = Result::okayWhen("Okay", $errorValue, $lazyThrow);
@@ -452,27 +440,27 @@ class ResultTest extends PHPUnit\Framework\TestCase {
 
       try {
          $after = $okay->run($lazyThrow, $lazyThrow);
-         $this->fail("Run will throw an exception");
-      } catch (\Exception $e) {}
+         $this->fail("Run will throw an Exception");
+      } catch (\Throwable $e) {}
 
       try {
          $after = $error->dataOrReturn($lazyThrow);
-         $this->fail("DataOrReturn will throw an exception");
-      } catch (\Exception $e) {}
+         $this->fail("DataOrReturn will throw an Exception");
+      } catch (\Throwable $e) {}
 
       try {
          $after = $okay->exists($lazyThrow);
-         $this->fail("Exists will throw an exception");
-      } catch (\Exception $e) {}
+         $this->fail("Exists will throw an Exception");
+      } catch (\Throwable $e) {}
 
       try {
          $after = $okay->runOnOkay($lazyThrow);
-         $this->fail("RunOnOkay will throw an exception");
-      } catch (\Exception $e) {}
+         $this->fail("RunOnOkay will throw an Exception");
+      } catch (\Throwable $e) {}
 
       try {
          $after = $okay->runOnError($lazyThrow);
-         $this->fail("RunOnError will throw an exception");
-      } catch (\Exception $e) {}
+         $this->fail("RunOnError will throw an Exception");
+      } catch (\Throwable $e) {}
    }
 }

--- a/tests/UnsafeResultTest.php
+++ b/tests/UnsafeResultTest.php
@@ -1,0 +1,430 @@
+<?php
+declare(strict_types = 1);
+
+require_once dirname(__FILE__) . '/../src/UnsafeResult.php';
+
+use Optional\UnsafeResult;
+
+class UnsafeResultTest extends PHPUnit\Framework\TestCase {
+   public function testCreateAndCheckExistence() {
+      $errorValue = "goodbye";
+      $errorResult = UnsafeResult::error($errorValue);
+
+      $this->assertFalse($errorResult->isOkay());
+
+      $okayThing = UnsafeResult::okay(1);
+      $okayNullable = UnsafeResult::okay(null);
+      $okayClass = UnsafeResult::okay(new SomeObject());
+
+      $this->assertTrue($okayThing->isOkay());
+      $this->assertTrue($okayNullable->isOkay());
+      $this->assertTrue($okayClass->isOkay());
+
+      $this->assertFalse($okayThing->isError());
+      $this->assertFalse($okayNullable->isError());
+      $this->assertFalse($okayClass->isError());
+
+      $noname = UnsafeResult::fromArray(['name' => 'value'], 'noname', 'oh no');
+      $this->assertTrue($noname->isError());
+      $this->assertFalse($noname->isOkay());
+
+      $name = UnsafeResult::fromArray(['name' => 'value'], 'name', 'oh no');
+      $this->assertTrue($name->isOkay());
+      $this->assertFalse($name->isError());
+
+      $nonameResult = UnsafeResult::fromArray(['name' => 'value'], 'noname');
+      $nonameNull = UnsafeResult::fromArray(['name' => 'value'], 'noname');
+      $this->assertFalse($nonameResult->isOkay());
+      $this->assertFalse($nonameNull->isOkay());
+
+      $error = UnsafeResult::okayNotNull(null, $errorValue);
+      $okay = UnsafeResult::okayNotNull('', $errorValue);
+
+      $this->assertFalse($error->isOkay());
+      $this->assertTrue($okay->isOkay());
+   }
+
+   public function testCreateAndCheckExistenceWhen() {
+      $errorValue = "goodbye";
+
+      $okayThing = UnsafeResult::okayWhen(1, $errorValue, function($x) { return $x > 0; });
+      $okayThing2 = UnsafeResult::okayWhen(-1, $errorValue, function($x) { return $x > 0; });
+
+      $this->assertSame($okayThing->dataOr(-5), 1);
+      $this->assertSame($okayThing2->dataOr(-5), -5);
+
+      $okayThing3 = UnsafeResult::errorWhen(1, $errorValue, function($x) { return $x > 0; });
+      $okayThing4 = UnsafeResult::errorWhen(-1, $errorValue, function($x) { return $x > 0; });
+
+      $this->assertSame($okayThing3->dataOr(-5), -5);
+      $this->assertSame($okayThing4->dataOr(-5), -1);
+
+      $errorThing = UnsafeResult::errorWhen(1, 100, function($x) { return $x > 0; });
+      $errorThing2 = UnsafeResult::errorWhen(-1, 100, function($x) { return $x > 0; });
+   }
+
+   public function testGettingValue() {
+      $errorValue = "goodbye";
+      $errorResult = UnsafeResult::error($errorValue);
+
+      $this->assertSame($errorResult->dataOr(-1), -1);
+
+      $someObject = new SomeObject();
+
+      $okayThing = UnsafeResult::okay(1);
+      $okayClass = UnsafeResult::okay($someObject);
+
+      $this->assertSame($okayThing->dataOr(-1), 1);
+      $this->assertSame($okayClass->dataOr(-1), $someObject);
+   }
+
+   public function testGettingValueLazily() {
+      $errorValue = "goodbye";
+      $errorResult = UnsafeResult::error($errorValue);
+
+      $this->assertSame($errorResult->dataOrReturn(function($x) { return $x; }), $errorValue);
+
+      $someObject = new SomeObject();
+
+      $okayThing = UnsafeResult::okay(1);
+      $okayClass = UnsafeResult::okay($someObject);
+
+      $this->assertSame($okayThing->dataOrReturn(function($x) { return $x; }), 1);
+      $this->assertSame($okayClass->dataOrReturn(function($x) { return $x; }), $someObject);
+
+      $this->assertSame($okayThing->dataOrReturn(function($x) {
+         $this->fail('Callback should not have been run!');
+         return $x;
+      }), 1);
+
+      $this->assertSame($okayClass->dataOrReturn(function($x) {
+         $this->fail('Callback should not have been run!');
+         return $x;
+      }), $someObject);
+   }
+
+   public function testGettingAlternitiveValue() {
+      $errorValue = "goodbye";
+      $someObject = new SomeObject();
+      $errorResult = UnsafeResult::error($errorValue);
+
+      $this->assertFalse($errorResult->isOkay());
+
+      $okayThing = $errorResult->orSetDataTo(1);
+      $okayClass = $errorResult->orSetDataTo($someObject);
+
+      $this->assertTrue($okayThing->isOkay());
+      $this->assertTrue($okayClass->isOkay());
+
+      $this->assertSame($okayThing->dataOr(-1), 1);
+      $this->assertSame($okayClass->dataOr("-1"), $someObject);
+
+      $lazyokay = $errorResult->orCreateResultWithData(function() { return 10; });
+      $this->assertTrue($lazyokay->isOkay());
+      $this->assertSame($lazyokay->dataOr(-1), 10);
+
+      $lazyPassThrough = $okayThing->orCreateResultWithData(function() { return 10; });
+      $this->assertTrue($lazyPassThrough->isOkay());
+      $this->assertSame($lazyPassThrough->dataOr(-1), 1);
+   }
+
+   public function testGettingAlternitiveResult() {
+      $errorValue = "goodbye";
+      $someObject = new SomeObject();
+      $errorResult = UnsafeResult::error($errorValue);
+
+      $this->assertFalse($errorResult->isOkay());
+
+      $errorResult2 = $errorResult->okayOr(UnsafeResult::error($errorValue));
+      $this->assertFalse($errorResult2->isOkay());
+
+      $okayThing = $errorResult->okayOr(UnsafeResult::okay(1));
+      $okayClass = $errorResult->okayOr(UnsafeResult::okay($someObject));
+
+      $this->assertTrue($okayThing->isOkay());
+      $this->assertTrue($okayClass->isOkay());
+
+      $this->assertSame($okayThing->dataOr(-1), 1);
+      $this->assertSame($okayClass->dataOr("-1"), $someObject);
+   }
+
+   public function testGettingAlternitiveResultLazy() {
+      $errorValue = "goodbye";
+      $someObject = new SomeObject();
+      $errorResult = UnsafeResult::error($errorValue);
+
+      $this->assertFalse($errorResult->isOkay());
+
+      $errorResult2 = $errorResult->createIfError(function($x) {
+         return UnsafeResult::error($x);
+      });
+      $this->assertFalse($errorResult2->isOkay());
+
+      $okayThing = $errorResult->createIfError(function($x) {
+         return UnsafeResult::okay(1);
+      });
+
+      $okayClass = $errorResult->createIfError(function($x) use ($someObject) {
+         return UnsafeResult::okay($someObject);
+      });
+
+      $this->assertTrue($okayThing->isOkay());
+      $this->assertTrue($okayClass->isOkay());
+
+      $this->assertSame($okayThing->dataOr(-1), 1);
+      $this->assertSame($okayClass->dataOr("-1"), $someObject);
+
+      $okayThing->createIfError(function($x) {
+         $this->fail('Callback should not have been run!');
+         return UnsafeResult::error($x);
+      });
+      $okayClass->createIfError(function($x) {
+         $this->fail('Callback should not have been run!');
+         return UnsafeResult::error($x);
+      });
+   }
+
+   public function testMatching() {
+      $errorValue = "goodbye";
+      $error = UnsafeResult::error($errorValue);
+      $okay = UnsafeResult::okay(1);
+
+      $failure = $error->run(
+            function($x) { return 2; },
+            function($x) { return $x; }
+      );
+
+      $success = $okay->run(
+            function($x) { return 2; },
+            function($x) { return $x; }
+      );
+
+      $this->assertSame($failure, $errorValue);
+      $this->assertSame($success, 2);
+
+      $hasMatched = false;
+      $error->run(
+            function($x) { $this->fail('Callback should not have been run!'); },
+            function($x) use (&$hasMatched) { $hasMatched = true; }
+      );
+      $this->assertTrue($hasMatched);
+
+      $hasMatched = false;
+      $okay->run(
+            function($x) use (&$hasMatched) { return $hasMatched = $x == 1; },
+            function($x) use (&$hasMatched) { $this->fail('Callback should not have been run!'); }
+      );
+      $this->assertTrue($hasMatched);
+
+      $error->runOnOkay(function($x) { $this->fail('Callback should not have been run!'); });
+
+      $hasMatched = false;
+      $okay->runOnOkay(function($x) use (&$hasMatched) { return $hasMatched = $x == 1; });
+      $this->assertTrue($hasMatched);
+
+      $okay->runOnError(function() { $this->fail('Callback should not have been run!'); });
+      $hasMatched = false;
+
+      $error->runOnError(function() use (&$hasMatched) { $hasMatched = true; });
+      $this->assertTrue($hasMatched);
+   }
+
+   public function testMapping() {
+      $errorValue = "goodbye";
+      $error = UnsafeResult::error($errorValue);
+      $okay = UnsafeResult::okay("a");
+      $okayNull = UnsafeResult::okay(null);
+
+      $errorUpper = $error->map(function($x) { return strtoupper($x); });
+      $okayUpper = $okay->map(function($x) { return strtoupper($x); });
+
+      $this->assertFalse($errorUpper->isOkay());
+      $this->assertTrue($okayUpper->isOkay());
+      $this->assertSame($errorUpper->dataOr("b"), "b");
+      $this->assertSame($okayUpper->dataOr("b"), "A");
+
+      $error = UnsafeResult::error("a");
+      $okay = UnsafeResult::okay("a");
+      $okayNull = UnsafeResult::okay(null);
+
+      $errorNotNull = $error->flatMap(function($x) use ($errorValue) { return UnsafeResult::okay($x)->notNull($errorValue); });
+      $notNull = $okay->flatMap(function($x) use ($errorValue) { return UnsafeResult::okay($x)->notNull($errorValue); });
+      $okayNullNotNull = $okayNull->flatMap(function($x) use ($errorValue) { return UnsafeResult::okay($x)->notNull($errorValue); });
+
+      $this->assertFalse($errorNotNull->isOkay());
+      $this->assertTrue($notNull->isOkay());
+      $this->assertFalse($okayNullNotNull->isOkay());
+
+      $errorUpper = $error->mapError(function($x) { return strtoupper($x); });
+      $okayUpper = $okay->mapError(function($x) { return strtoupper($x); });
+
+      $this->assertFalse($errorUpper->isOkay());
+      $this->assertTrue($okayUpper->isOkay());
+      $this->assertSame($errorUpper->errorOr("b"), "A");
+      $this->assertSame($okayUpper->errorOr("b"), "b");
+   }
+
+   public function testFiltering() {
+      $errorValue = "goodbye";
+      $error = UnsafeResult::error($errorValue);
+      $okay = UnsafeResult::okay("a");
+
+      $okayTrue = $okay->toError($errorValue);
+      $okayFalse = $okay->toError($errorValue);
+      $errorTrue = $error->toError($errorValue);
+      $errorFalse = $error->toError($errorValue);
+
+      $this->assertFalse($okayFalse->isOkay());
+
+      $this->assertFalse($errorTrue->isOkay());
+      $this->assertFalse($errorFalse->isOkay());
+
+      $errorNotA = $error->toErrorIf(function($x) { return $x != "a"; }, $errorValue);
+      $okayNotA = $okay->toErrorIf(function($x) { return $x != "a"; }, $errorValue);
+      $errorA = $error->toErrorIf(function($x) { return $x == "a"; }, $errorValue);
+      $okayA = $okay->toErrorIf(function($x) { return $x == "a"; }, $errorValue);
+
+      $this->assertFalse($errorNotA->isOkay());
+      $this->assertFalse($okayNotA->isOkay());
+      $this->assertFalse($errorA->isOkay());
+      $this->assertTrue($okayA->isOkay());
+
+      $okayNull = UnsafeResult::okay(null);
+      $this->assertTrue($okayNull->isOkay());
+      $errorNull = $okayNull->notNull($errorValue);
+      $this->assertFalse($errorNull->isOkay());
+
+      $okayEmpty = UnsafeResult::okay("");
+      $this->assertTrue($okayEmpty->isOkay());
+      $errorEmpty = $okayEmpty->notFalsy($errorValue);
+      $this->assertFalse($errorEmpty->isOkay());
+   }
+
+   public function testContains() {
+      $errorValue = "goodbye";
+      $error = UnsafeResult::error($errorValue);
+      $okayString = UnsafeResult::okay("a");
+      $okayInt = UnsafeResult::okay(1);
+
+      $this->assertTrue($okayString->contains("a"));
+      $this->assertFalse($okayString->contains("A"));
+      $this->assertFalse($okayString->contains(1));
+      $this->assertFalse($okayString->contains(null));
+
+      $this->assertTrue($okayInt->contains(1));
+      $this->assertFalse($okayInt->contains(2));
+      $this->assertFalse($okayInt->contains("A"));
+      $this->assertFalse($okayInt->contains(null));
+
+      $this->assertFalse($error->contains(1));
+      $this->assertFalse($error->contains(2));
+      $this->assertFalse($error->contains("A"));
+      $this->assertFalse($error->contains(null));
+
+      $errorString = UnsafeResult::error("a");
+      $errorInt = UnsafeResult::error(1);
+
+      $this->assertTrue($errorString->errorContains("a"));
+      $this->assertFalse($errorString->errorContains("A"));
+      $this->assertFalse($errorString->errorContains(1));
+      $this->assertFalse($errorString->errorContains(null));
+
+      $this->assertTrue($errorInt->errorContains(1));
+      $this->assertFalse($error->errorContains(2));
+      $this->assertFalse($error->errorContains("A"));
+      $this->assertFalse($error->errorContains(null));
+   }
+
+   public function testExists() {
+      $errorValue = "goodbye";
+      $error = UnsafeResult::error($errorValue);
+      $okay = UnsafeResult::okay(10);
+
+      $errorFalse = $error->exists(function($x) { return $x == 10; });
+      $okayTrue = $okay->exists(function($x) { return $x >= 10; });
+      $okayFalse = $okay->exists(function($x) { return $x == "Thing"; });
+
+      $this->assertTrue($okayTrue);
+      $this->assertFalse($errorFalse);
+      $this->assertFalse($okayFalse);
+   }
+
+   public function testFlatMap() {
+      $okayPerson = [
+         'name' => [
+            'first' => 'First',
+            'last' => 'Last'
+         ]
+      ];
+
+      $person = UnsafeResult::fromArray($okayPerson, 'name', 'name was missing');
+
+      $name = $person->andThen(function($person) {
+         $fullName = $person['first'] . $person['last'];
+
+         try {
+            $thing = SomeComplexThing::doWork($fullName);
+         } catch (ErrorException $e) {
+            return UnsafeResult::error('SomeComplexThing had an error!');
+         }
+
+         return UnsafeResult::okay($thing);
+      });
+
+      $this->assertSame($name->dataOr(''), 'FirstLast');
+   }
+
+   public function testFlatMapWithException() {
+      $okayPerson = [
+         'name' => [
+            'first' => 'First',
+            'last' => 'Last'
+         ]
+      ];
+
+      $person = UnsafeResult::fromArray($okayPerson, 'name', 'name was missing');
+
+      $name = $person->andThen(function($person) {
+         $fullName = $person['first'] . $person['last'];
+
+         try {
+            $thing = SomeComplexThing::doWork($fullName, "Forcing exception");
+         } catch (\Exception $e) {
+            return UnsafeResult::error('SomeComplexThing had an error!');
+         }
+
+         return UnsafeResult::okay($thing);
+      });
+
+      $this->assertFalse($name->isOkay());
+      $this->assertSame($name->dataOr('oh no'), 'oh no');
+   }
+
+   public function testSafelyMapWithException() {
+      $okayPerson = [
+         'name' => [
+            'first' => 'First',
+            'last' => 'Last'
+         ]
+      ];
+
+      $person = UnsafeResult::fromArray($okayPerson, 'name', 'name was missing');
+
+      $name = $person->mapSafely(function($person): string {
+         $fullName = $person['first'] . $person['last'];
+         return SomeComplexThing::doWork($fullName, "Forcing exception");
+      });
+
+      $this->assertFalse($name->isOkay());
+      $this->assertSame($name->dataOr('oh no'), 'oh no');
+
+      $out = 'This should change';
+
+      $name->run(
+         function ($okayValue) { $this->fail('Callback should not have been run!'); },
+         function ($exception) use(&$out) { $out = $exception->getMessage(); }
+      );
+
+      $this->assertSame($out, "Forcing exception");
+   }
+}


### PR DESCRIPTION
This pull marks a big step forward towards 2.0. Namely, the Result class is now always safe when transforming the data. Any error causes the error to be wrapped, then thrown when unboxing.

I did not want to remove the behavior from the previous result class. As such, I have moved this class to `UnsafeResult` which allows `dataOr($otherValue)`. 