### PR TITLE
Psalm: Get to error level 1

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="5.2.0@fb685a16df3050d4c18d8a4100fe83abe6458cba">
+  <file src="tests/EitherTest.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>EitherTest</code>
+      <code>EitherTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+  <file src="tests/OptionTest.php">
+    <PropertyNotSetInConstructor occurrences="2">
+      <code>OptionTest</code>
+      <code>OptionTest</code>
+    </PropertyNotSetInConstructor>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="true"
     errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,8 +12,4 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
-    </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     totallyTyped="true"
+    errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,9 +5,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="tests" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src/Either.php
+++ b/src/Either.php
@@ -5,15 +5,8 @@ declare(strict_types = 1);
 namespace Optional;
 
 /**
- * @psalm-immutable
  * @template TLeft
  * @template TRight
- *
- * @psalm-suppress ImpureFunctionCall
- *   Since we want to allow users to pass in function that are possibly non-pure
- *   I am in debate around this because it opens up the library to mutation, based bugs.
- *   If we force purity, then the utility of the library decreases.
- *   EX: Option::some(false)->match(fn() => $this->passUnitTest(), fn() => $this->failUnitTest())
  */
 class Either {
    /**
@@ -37,6 +30,7 @@ class Either {
    /**
     * @psalm-param TLeft $leftValue
     * @psalm-param TRight $rightValue
+    * @psalm-mutation-free
     **/
    private function __construct($leftValue, $rightValue, bool $isLeft) {
       $this->isLeft = $isLeft;
@@ -121,7 +115,6 @@ class Either {
     *
     *  - `$valueFactoryFunc` must follow this interface `callable(TRight):TLeft`
     *
-    * @psalm-mutation-free
     * @template TTLeft
     * @psalm-param callable(TRight):TTLeft $alternativeFactory
     * @psalm-return (TRight is never ? TLeft : TTLeft)
@@ -139,7 +132,6 @@ class Either {
     *
     *  - `$valueFactoryFunc` must follow this interface `callable(TRight):TLeft`
     *
-    * @psalm-mutation-free
     * @template TTRight
     * @psalm-param callable(TLeft):TTRight $alternativeFactory
     * @psalm-return (TLeft is never ? TRight : TTRight)
@@ -206,7 +198,6 @@ class Either {
     *  - `$valueFactoryFunc` must follow this interface `callable(TRight):TLeft`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template TTLeft
     * @psalm-param callable(TRight):TTLeft $alternativeFactory
     * @psalm-return (TRight is never ? Either<TLeft, TRight> : self<TTLeft, never>)
@@ -227,7 +218,6 @@ class Either {
     *  - `$alternativeFactory` must follow this interface `callable(TRight):TLeft`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template TTRight
     * @psalm-param callable(TLeft):TTRight $alternativeFactory
     * @psalm-return (TLeft is never ? Either<TLeft, TRight> : self<never, TTRight>)
@@ -300,7 +290,6 @@ class Either {
     *  - `$alternativeEither` must be of type `callable(TRight):Either<TLeft, TRight> `
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template TLeftOther
     * @template TRightOther
     * @psalm-param callable(TRight):Either<TLeftOther, TRightOther> $alternativeEitherFactory
@@ -320,7 +309,6 @@ class Either {
     *  - `$alternativeEither` must be of type `callable(TLeft):Either<TLeft, TRight> `
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template TLeftOther
     * @template TRightOther
     * @psalm-param callable(TLeft):Either<TLeftOther, TRightOther> $alternativeEitherFactory
@@ -360,7 +348,6 @@ class Either {
     *  - `$left` must follow this interface `callable(TLeft):U`
     *  - `$right` must follow this interface `callable(TRight):U`
     *
-    * @psalm-mutation-free
     * @template ULeft
     * @template URight
     * @psalm-param callable(TLeft):ULeft $left
@@ -388,7 +375,6 @@ class Either {
     *
     *  - `$left` must follow this interface `callable(TLeft):U`
     *
-    * @psalm-mutation-free
     * @psalm-param callable(TLeft) $left
     **/
    public function matchLeft(callable $left): void {
@@ -414,7 +400,6 @@ class Either {
     *
     *  - `$right` must follow this interface `callable(TRight):U`
     *
-    * @psalm-mutation-free
     * @psalm-param callable(TRight) $right
     **/
    public function matchRight(callable $right): void {
@@ -444,7 +429,6 @@ class Either {
     *  - `$mapFunc` must follow this interface `callable(TLeft):ULeft`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template ULeft
     * @psalm-param callable(TLeft):ULeft $mapFunc
     * @psalm-return Either<ULeft, TRight>
@@ -478,7 +462,6 @@ class Either {
     *  - `$mapFunc` must follow this interface `callable(TRight):URight`
     *  - Returns `Either<TLeft, URight>`
     *
-    * @psalm-mutation-free
     * @template URight
     * @psalm-param callable(TRight):URight $mapFunc
     * @psalm-return (TLeft is never ? Either<TLeft, URight> : Either<TLeft, TRight>)
@@ -487,7 +470,7 @@ class Either {
       /** @psalm-var callable(TLeft):Either<TLeft, URight> **/
       $leftFunc =
       /** @psalm-param TLeft $value */
-      function($value) use ($mapFunc): Either {
+      function($value): Either {
          return self::left($value);
       };
 
@@ -520,7 +503,6 @@ class Either {
     *  - `$mapFunc` must follow this interface `callable(TLeft):Either<ULeft, TRight>`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template ULeft
     * @psalm-param callable(TLeft):ULeft $mapFunc
     * @psalm-return Either<ULeft, TRight>|Either<never, \Exception>
@@ -563,7 +545,6 @@ class Either {
     *  - `$mapFunc` must follow this interface `callable(TLeft):Either<ULeft, TRight>`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template ULeft
     * @psalm-param callable(TLeft):Either<ULeft, TRight> $mapFunc
     * @psalm-return (TRight is never ? Either<ULeft, TRight> : Either<TLeft, TRight>)
@@ -588,7 +569,6 @@ class Either {
     *  - `$alternativeFactory` must follow this interface `callable(TLeft):Either<ULeft, TRight>`
     *  - Returns `Either<ULeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template ULeft
     * @psalm-param callable(TLeft):Either<ULeft, TRight> $mapFunc
     * @psalm-return (TRight is never ? Either<ULeft, TRight> : Either<TLeft, TRight>)
@@ -656,7 +636,6 @@ class Either {
     *  - `$filterFunc` must follow this interface `callable(TLeft):bool`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template TTRight
     * @psalm-param callable(TLeft):bool $filterFunc
     * @psalm-param TTRight $rightValue
@@ -679,7 +658,6 @@ class Either {
     *  - `$filterFunc` must follow this interface `callable(TRight):bool`
     *  - Returns `Either<TLeft, TRight>`
     *
-    * @psalm-mutation-free
     * @template TTLeft
     * @psalm-param callable(TRight):bool $filterFunc
     * @psalm-param TTLeft $leftValue
@@ -845,7 +823,6 @@ class Either {
     *
     *  - `$filterFunc` must follow this interface `callable(TLeft):bool`
     *
-    * @psalm-mutation-free
     * @psalm-param callable(TLeft):bool $existsFunc
     **/
    public function existsLeft(callable $existsFunc): bool {
@@ -863,7 +840,6 @@ class Either {
     *
     *  - `$filterFunc` must follow this interface `callable(TRight):bool`
     *
-    * @psalm-mutation-free
     * @psalm-param callable(TRight):bool $existsFunc
     **/
    public function existsRight(callable $existsFunc): bool {
@@ -886,7 +862,6 @@ class Either {
     *
     *  - Returns `Option<U>`
     *
-    * @psalm-mutation-free
     * @template U
     * @psalm-return Option<U>
     **/
@@ -901,8 +876,8 @@ class Either {
 
       /** @psalm-var callable(TRight):Option<U> **/
       $rightFunc =
-      /** @psalm-param TLeft $rightValue **/
-      function($rightValue): Option {
+      /** @psalm-param TRight $_rightValue **/
+      function($_rightValue): Option {
          return Option::none();
       };
 
@@ -977,8 +952,6 @@ class Either {
     *  - `$filterFunc` must follow this interface `callable(TTLeft): bool`
     *  - Returns `Either<mixed, TTRight>`
     *
-    * @psalm-mutation-free
-    * @psalm-pure
     * @template TTLeft
     * @template TTRight
     * @psalm-param TTLeft $leftValue
@@ -1007,8 +980,6 @@ class Either {
     *  - `$filterFunc` must follow this interface `callable(TTLeft): bool`
     *  - Returns `Either<mixed, TTRight>`
     *
-    * @psalm-mutation-free
-    * @psalm-pure
     * @template TTLeft
     * @template TTRight
     * @psalm-param TTLeft $leftValue

--- a/src/Option.php
+++ b/src/Option.php
@@ -5,14 +5,8 @@ declare(strict_types = 1);
 namespace Optional;
 
 /**
- * @psalm-immutable
  * @template T
  *
- * @psalm-suppress ImpureFunctionCall
- *   Since we want to allow users to pass in function that are possibly non-pure
- *   I am in debate around this because it opens up the library to mutation, based bugs.
- *   If we force purity, then the utility of the library decreases.
- *   EX: Option::some(false)->match(fn() => $this->passUnitTest(), fn() => $this->failUnitTest())
  */
 class Option {
    /**
@@ -27,7 +21,10 @@ class Option {
     */
    private $value;
 
-   /** @psalm-param T $value */
+   /**
+    * @psalm-param T $value
+    * @psalm-mutation-free
+    */
    private function __construct($value, bool $hasValue) {
       $this->hasValue = $hasValue;
       $this->value = $value;
@@ -87,7 +84,6 @@ class Option {
     *
     *  - `$alternativeFactory` must follow this interface `callable():T`
     *
-    * @psalm-mutation-free
     * @template TT
     * @psalm-param callable():TT $alternativeFactory
     * @psalm-return (T is never ? TT : T)
@@ -137,8 +133,6 @@ class Option {
     *
     *  - `$alternativeFactory` must follow this interface `callable():T`
     *  - Returns `Option<T>`
-    *
-    * @psalm-mutation-free
     *
     * @template TT
     * @psalm-param callable():TT $alternativeFactory
@@ -191,7 +185,6 @@ class Option {
     *  - `$alternativeOptionFactory` must follow this interface `callable():Option<T>`
     *  - Returns `Option<T>`
     *
-    * @psalm-mutation-free
     * @template TT
     * @psalm-param callable():Option<TT> $alternativeOptionFactory
     * @psalm-return (T is never ? Option<TT> : Option<T>)
@@ -229,7 +222,6 @@ class Option {
     *  - `$some` must follow this interface `callable(T):U`
     *  - `$none` must follow this interface `callable():U`
     *
-    * @psalm-mutation-free
     * @template U
     * @psalm-param callable(T):U $some
     * @psalm-param callable():U $none
@@ -254,8 +246,6 @@ class Option {
     * _Notes:_
     *
     *  - `$some` must follow this interface `callable(T):U`
-    *
-    * @psalm-mutation-free
     * @psalm-param callable(T) $some
     **/
    public function matchSome(callable $some): void {
@@ -310,7 +300,6 @@ class Option {
     *  - `$mapFunc` must follow this interface `callable(T):U`
     *  - Returns `Option<U>`
     *
-    * @psalm-mutation-free
     * @template U
     * @psalm-param $mapFunc callable(T):U
     * @psalm-return Option<U>
@@ -348,8 +337,6 @@ class Option {
     *
     *  - `$mapFunc` must follow this interface `callable(T):U`
     *  - Returns `Option<U>`
-    *
-    * @psalm-mutation-free
     *
     * @template U
     *
@@ -389,7 +376,6 @@ class Option {
     *  });
     * ```
     *
-    * @psalm-mutation-free
     * Note: `$mapFunc` must follow this interface `function mapFunc(mixed $value): Option`
     * @template U
     * @psalm-param callable(T):Option<U> $mapFunc
@@ -431,7 +417,6 @@ class Option {
     *
     * Note: `$mapFunc` must follow this interface `function mapFunc(mixed $value): Option`
     *
-    * @psalm-mutation-free
     * @template U
     * @psalm-param callable(T):Option<U> $mapFunc
     * @psalm-return Option<U>
@@ -463,8 +448,6 @@ class Option {
     *
     *  - `$filterFunc` must follow this interface `callable(T):bool`
     *  - Returns `Option<T>`
-    *
-    * @psalm-mutation-free
     *
     * @psalm-param callable(T):bool $filterFunc
     *
@@ -558,7 +541,6 @@ class Option {
     *  - `$existsFunc` must follow this interface `callable(T):bool`
     *  - Returns `Option<T>`
     *
-    * @psalm-mutation-free
     * @psalm-param callable(T):bool $existsFunc
     **/
    public function exists(callable $existsFunc): bool {
@@ -630,9 +612,6 @@ class Option {
     *  - `$filterFunc` must follow this interface `callable(TT):bool`
     *  - Returns `Option<TT>`
     *
-    * @psalm-mutation-free
-    *
-    * @psalm-pure
     *
     * @template TT
     *
@@ -661,10 +640,6 @@ class Option {
     *  - `$filterFunc` must follow this interface `callable(TT):bool`
     *  - Returns `Option<TT>`
     *
-    * @psalm-mutation-free
-    *
-    * @psalm-pure
-    *
     * @template TT
     *
     * @psalm-param TT $someValue
@@ -689,10 +664,6 @@ class Option {
     * _Notes:_
     *
     * - Returns `Option<TT>`
-    *
-    * @psalm-mutation-free
-    *
-    * @psalm-pure
     *
     * @template TT
     *

--- a/tests/OptionTest.php
+++ b/tests/OptionTest.php
@@ -77,12 +77,10 @@ class OptionTest extends TestCase {
 
       $this->assertSame($someThing->valueOrCreate(function() {
          $this->fail('Callback should not have been run!');
-         return -1;
       }), 1);
 
       $this->assertSame($someClass->valueOrCreate(function() {
          $this->fail('Callback should not have been run!');
-         return -1;
       }), $someObject);
    }
 
@@ -158,12 +156,15 @@ class OptionTest extends TestCase {
       $this->assertSame($someThing->valueOr(-1), 1);
       $this->assertSame($someClass->valueOr("-1"), $someObject);
 
+      /** @psalm-suppress UnusedMethodCall so we can show that psalm even knows this is impossible */
       $someThing->elseCreate(
          /** @return never */
          function() {
             $this->fail('Callback should not have been run!');
          }
-   );
+      );
+
+      /** @psalm-suppress UnusedMethodCall so we can show that psalm even knows this is impossible */
       $someClass->elseCreate(
          /** @return never */
          function() {
@@ -177,40 +178,39 @@ class OptionTest extends TestCase {
       $some = Option::some(1);
 
       $failure = $none->match(
-          function($x) { return 2; },
+          function($_x) { return 2; },
           function() { return -2; }
       );
 
       $success = $some->match(
-          function($x) { return 2; },
+          function($_x) { return 2; },
           function() { return -2; }
       );
 
       $this->assertSame($failure, -2);
       $this->assertSame($success, 2);
 
-      $hasMatched = false;
-      $none->match(
-          function($x) { $this->fail('Callback should not have been run!'); },
-          function() use (&$hasMatched) { $hasMatched = true; }
+      $hasMatched = $none->match(
+          function($_x) { $this->fail('Callback should not have been run!'); },
+          function() { return true; }
       );
       $this->assertTrue($hasMatched);
 
-      $hasMatched = false;
-      $some->match(
-          function($x) use (&$hasMatched) { return $hasMatched = $x == 1; },
-          function() use (&$hasMatched) { $this->fail('Callback should not have been run!'); }
+      $hasMatched = $some->match(
+          function($x) { return $x == 1; },
+          function() { $this->fail('Callback should not have been run!'); }
       );
       $this->assertTrue($hasMatched);
 
+      /** @psalm-suppress UnusedMethodCall so we can show that psalm even knows this is impossible */
       $none->matchSome(function(int $_x) { $this->fail('Callback should not have been run!'); });
 
       $hasMatched = false;
       $some->matchSome(function(int $x) use (&$hasMatched) { return $hasMatched = $x == 1; });
       $this->assertTrue($hasMatched);
 
+      /** @psalm-suppress UnusedMethodCall so we can show that psalm even knows this is impossible */
       $some->matchNone(function() { $this->fail('Callback should not have been run!'); });
-      $hasMatched = false;
 
       $none->matchNone(function() use (&$hasMatched) { $hasMatched = true; });
       $this->assertTrue($hasMatched);


### PR DESCRIPTION
We now will be totally type with psalm as strict as possible.

The most notable choice here is that we are no longer immutable.

Psalm does not have a way to opt out a method from immutability.
But, psalm will yell if you have something like:

Option::none()->matchNone(fn(): void => echo "something");

Notice the void there? We know matchNone / matchSome should have no return value
thus, the function *must* have side effects.

Since I could not teach psalm just these functions are immutable, I flipped my approach.

We are not immutable, but all methods that can be marked mutation free, will be.

This is as close as I can get to perfectly describing how the code is actually working.

One other note is the code removal in tests. All my psalm changes allow for the type system
to yell in cases where code is impossible. EX:
Option::none()->matchSome(fn() => echo "This is impossible");

I kept a few as examples that psalm will yell at you about it, but removed other examples.